### PR TITLE
revert: dark mode on HTML link component

### DIFF
--- a/packages/html/ds/src/link/link.html
+++ b/packages/html/ds/src/link/link.html
@@ -1,13 +1,4 @@
 {% macro govieLink(props) %}
-  {% macro getDarkClass(dark) %}
-    {% if dark %}
-      gi-text-white
-      hover:gi-text-white
-    {% else %}
-      gi-text-blue-700
-      hover:gi-text-blue-800
-    {% endif %}
-  {% endmacro %}
   {% macro getUnderlineClass(noUnderline) %}
     {% if not noUnderline %}
       gi-underline
@@ -15,15 +6,11 @@
       focus:gi-no-underline
     {% endif %}
   {% endmacro %}
-  {% macro getVisitedClass(noVisited, dark) %}
+  {% macro getVisitedClass(noVisited) %}
     {% if noVisited %}
       visited:gi-text-blue-700
     {% else %}
-      {% if dark %}
-        visited:gi-text-white
-      {% else %}
-        visited:gi-text-purple-700
-      {% endif %}
+      visited:gi-text-purple-700
     {% endif %}
   {% endmacro %}
   {% macro getExternalAttribute(isExternal) %}
@@ -36,8 +23,9 @@
     {{ getExternalAttribute(props.external) | trim }}
     class="
       {{ getUnderlineClass(props.noUnderline) | trim }}
-      {{ getVisitedClass(props.noVisited, props.dark) | trim }}
-      {{ getDarkClass(props.dark) | trim }}
+      {{ getVisitedClass(props.noVisited) | trim }}
+      gi-text-blue-700
+      hover:gi-text-blue-800
       hover:gi-decoration-[max(3px,0.1875rem,0.12em)]
       focus:gi-outline
       focus:gi-text-gray-950

--- a/packages/html/ds/src/link/link.schema.ts
+++ b/packages/html/ds/src/link/link.schema.ts
@@ -20,11 +20,6 @@ export const linkSchema = zod.object({
       description: 'To open the link in a new tab.',
     })
     .optional(),
-  dark: zod
-    .boolean({
-      description: 'Show white links on dark backgrounds.',
-    })
-    .optional(),
   noUnderline: zod
     .boolean({
       description: 'To remove underlines from links.',

--- a/packages/html/ds/src/link/link.stories.ts
+++ b/packages/html/ds/src/link/link.stories.ts
@@ -44,12 +44,6 @@ export const Default: Story = {
       control: 'boolean',
       type: { name: 'boolean' },
     },
-    dark: {
-      description:
-        'Show white links on dark backgrounds — for example, in headers, custom components, and patterns with darker backgrounds.',
-      control: 'boolean',
-      type: { name: 'boolean' },
-    },
   },
   args: {
     href: '#',
@@ -78,19 +72,5 @@ export const NoVisited: Story = {
     href: '#',
     label: 'Link',
     noVisited: true,
-  },
-};
-
-export const Dark: Story = {
-  args: {
-    href: '#',
-    label: 'Link',
-    dark: true,
-  },
-  parameters: {
-    backgrounds: {
-      default: 'dark',
-      values: [{ name: 'dark', value: '#1d70b8' }],
-    },
   },
 };

--- a/packages/html/ds/src/link/link.test.ts
+++ b/packages/html/ds/src/link/link.test.ts
@@ -77,34 +77,6 @@ describe('link', () => {
     );
   });
 
-  it('should have white text on dark background', () => {
-    const screen = renderLink({
-      href: 'https://example.com',
-      label: 'Example Link',
-      dark: true,
-    });
-
-    const linkElement = screen.getByRole('link');
-
-    // Check if the dark styles are applied
-    expect(linkElement.classList.contains('gi-text-white')).toBe(true);
-    expect(linkElement.classList.contains('hover:gi-text-white')).toBe(true);
-  });
-
-  it('should have correct visited style on dark background', () => {
-    const screen = renderLink({
-      href: 'https://example.com',
-      label: 'Example Link',
-      dark: true,
-      noVisited: false,
-    });
-
-    const linkElement = screen.getByRole('link');
-
-    // Check if the visited style for dark background is applied
-    expect(linkElement.classList.contains('visited:gi-text-white')).toBe(true);
-  });
-
   it('should pass axe tests', async () => {
     const screen = renderLink({
       href: 'https://example.com',

--- a/packages/html/ds/styles.css
+++ b/packages/html/ds/styles.css
@@ -10,8 +10,3 @@
   max-height: 0;
   opacity: 0;
 }
-
-/* Workaround solution for <https://github.com/storybookjs/storybook/issues/13612> */
-.sb-show-main {
-  transition: none !important; /* !important needed to counter inline style */
-}


### PR DESCRIPTION
Revert dark mode changes on link component.

Storybook testing:
![Screenshot 2024-09-04 at 12 21 12](https://github.com/user-attachments/assets/ac5adf85-4db1-4f43-bfc4-513d7bf4635d)
