### PR TITLE
chore: enable html in paragraph

### DIFF
--- a/examples/wagtail/core/jinja/home_page.jinja
+++ b/examples/wagtail/core/jinja/home_page.jinja
@@ -30,8 +30,10 @@
     {{ govieHeading({ 'size': 'xl', 'tag': 'h1', 'text': 'Heading'}) }}
 
     <h2>Paragraph (Global)</h2>
+    {% set paragraphContentWithLink = govieLink({ "href": "#", "label": "with Link", }) %}
+    {% set paragraphContent = "This is the paragraph content " ~ paragraphContentWithLink %}
     {{ govieParagraph({
-        "content": "This is a paragraph.",
+        "content": paragraphContent,
         "as": "p",
         "size": "lg"
     }) }}
@@ -39,8 +41,6 @@
     <p class="govie-body">We have sent you a confirmation email.</p>
 
     <h2>Container (Global)</h2>
-
-    {% set headingForContainer = govieHeading({ 'size': 'xl', 'tag': 'h1', 'text': 'Heading'}) %}
     {{ govieContainer({
         "html": govieHeading({ 'size': 'md', 'tag': 'h1', 'text': 'Heading Under Container'})
     }) }}

--- a/packages/html/ds/src/paragraph/paragraph.html
+++ b/packages/html/ds/src/paragraph/paragraph.html
@@ -10,10 +10,10 @@
   {% endmacro %}
 
   {% if props.as == 'p' %}
-    <p class="{{ getSizeClass(props.size) | trim }} gi-mt-0 gi-mb-8 gi-max-w-prose">{{ props.content }}</p>
+    <p class="{{ getSizeClass(props.size) | trim }} gi-mt-0 gi-mb-8 gi-max-w-prose">{{ props.content | safe | trim }}</p>
   {% elif props.as == 'span' %}
-    <span class="{{ getSizeClass(props.size) | trim }} gi-my-0">{{ props.content }}</span>
+    <span class="{{ getSizeClass(props.size) | trim }} gi-my-0">{{ props.content | safe | trim }}</span>
   {% else %}
-    <p class="{{ getSizeClass(props.size) | trim }} gi-mt-2 gi-mb-8 gi-max-w-prose">{{ props.content }}</p>
+    <p class="{{ getSizeClass(props.size) | trim }} gi-mt-2 gi-mb-8 gi-max-w-prose">{{ props.content | safe | trim }}</p>
   {% endif %}
 {% endmacro %}

--- a/packages/html/ds/src/paragraph/paragraph.test.ts
+++ b/packages/html/ds/src/paragraph/paragraph.test.ts
@@ -70,6 +70,18 @@ describe('govieParagraph', () => {
     expect(pElement.classList.contains('xl:gi-text-md')).toBe(true);
   });
 
+  it('should safely render HTML content', () => {
+    const screen = renderParagraph({
+      as: AsEnum.Paragraph,
+      content: '<a href="#">Anchor tag</a>',
+      size: SizeEnum.Small,
+    });
+
+    const pElement = screen.getByText('Anchor tag');
+    expect(pElement).toBeTruthy();
+    expect(pElement.innerHTML).toContain('Anchor tag');
+  });
+
   it('should pass axe accessibility tests', async () => {
     const screen = renderParagraph({
       as: AsEnum.Paragraph,


### PR DESCRIPTION
- Enable html content with paragraph and associated tests.
- Example wagtail implementation with `govieLink` macro.

![Screenshot 2024-09-05 at 14 47 56](https://github.com/user-attachments/assets/3999046a-efa6-4ad6-baef-4141826c857f)
