### PR TITLE
docs: update copy code block and meta tag

### DIFF
--- a/packages/html/storybook/.storybook/preview.tsx
+++ b/packages/html/storybook/.storybook/preview.tsx
@@ -59,7 +59,7 @@ const preview: Preview = {
 
           const lines = [
             '// Macro',
-            `{{ ${parameters.macro.name}(${macroOptions})} }}`,
+            `{{ ${parameters.macro.name}(${macroOptions}) }}`,
             '',
             '// HTML',
             renderedMacro,

--- a/packages/html/storybook/docs/introduction.mdx
+++ b/packages/html/storybook/docs/introduction.mdx
@@ -1,3 +1,7 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Introduction" />
+
 ## Get started
 
-* The components should only be used by early adopters and collaborate with the design system team as the components are currently in the alpha phase. 
+- The components should only be used by early adopters and collaborate with the design system team as the components are currently in the alpha phase.

--- a/packages/html/storybook/docs/precompiled.mdx
+++ b/packages/html/storybook/docs/precompiled.mdx
@@ -1,3 +1,7 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Precompiled" />
+
 # Install using precompiled files
 
 You can install the Gov IE Frontend global HTML components by copying the CSS, JavaScript, and macro files into your project.


### PR DESCRIPTION
- Introduction and precompiled title updates.
- Copy code block content. Extra curly bracket removed which was resulting in an error during copy.

Storybook titles:
![Screenshot 2024-09-05 at 15 15 12](https://github.com/user-attachments/assets/b3726884-dc19-4e04-91e2-7465debb745e)

Example on Link component:
![Screenshot 2024-09-05 at 15 15 35](https://github.com/user-attachments/assets/b44fccf5-259b-4ce3-8b05-863a17a0c496)
