### PR TITLE
chore: refactor children prop

### DIFF
--- a/examples/vite/src/application.tsx
+++ b/examples/vite/src/application.tsx
@@ -94,33 +94,33 @@ export function App() {
             <TextInput
               id="text-input-id"
               error={{
-                children: "Error: Please correct this issue.",
+                text: "Error: Please correct this issue.",
               }}
               hint={{
-                children: "Hint: This is a helpful hint.",
+                text: "Hint: This is a helpful hint.",
               }}
               label={{
-                children: "Label",
+                text: "Label",
                 htmlFor: "text-input-id",
               }}
               suffix="KG"
             />
             <TextArea
               error={{
-                children: "Error: Please correct this issue.",
+                text: "Error: Please correct this issue.",
               }}
               hint={{
-                children: "Hint: This is a helpful hint.",
+                text: "Hint: This is a helpful hint.",
               }}
               id="textarea-id"
               label={{
-                children: "Label",
+                text: "Label",
                 htmlFor: "textarea-id",
               }}
             />
             <Select
               id="unique-id"
-              label={{ content: "Label" }}
+              label={{ text: "Label" }}
               options={[
                 {
                   label: "Option 1",
@@ -141,11 +141,11 @@ export function App() {
         <hr />
         <FileUpload
           error={{
-            children: "Error: File must be smaller than 5MB.",
+            text: "Error: File must be smaller than 5MB.",
           }}
           id="file-upload-id"
           label={{
-            children: "Upload File",
+            text: "Upload File",
             htmlFor: "file-upload-id",
           }}
         />

--- a/packages/react/ds/src/checkbox/checkbox.tsx
+++ b/packages/react/ds/src/checkbox/checkbox.tsx
@@ -41,7 +41,7 @@ const Checkbox = ({
           {label}
         </label>
       </div>
-      {hint && <HintText className="gi-mb-0">{hint}</HintText>}
+      {hint && <HintText text={hint} className="gi-mb-0" />}
     </div>
   );
 };

--- a/packages/react/ds/src/checkbox/checkboxes-group.tsx
+++ b/packages/react/ds/src/checkbox/checkboxes-group.tsx
@@ -43,11 +43,11 @@ const CheckboxesGroup = ({
           ) : (
             title.value
           )}
-          {title.hint && <HintText className="gi-mb-0">{title.hint}</HintText>}
+          {title.hint && <HintText text={title.hint} className="gi-mb-0" />}
         </legend>
         <div className="gi-flex gi-flex-col gi-gap-2.5">
           {errorMessage && (
-            <ErrorText className="gi-mb-0">{errorMessage}</ErrorText>
+            <ErrorText text={errorMessage} className="gi-mb-0" />
           )}
           {items.map((checkbox, index) => (
             <Checkbox

--- a/packages/react/ds/src/error-text/error-text.stories.tsx
+++ b/packages/react/ds/src/error-text/error-text.stories.tsx
@@ -28,17 +28,17 @@ export const Default: Story = {
         defaultValue: { summary: ErrorSize.md },
       },
     },
-    children: {
+    text: {
       control: 'text',
       table: {
         category: 'Content',
-        type: { summary: 'React.ReactNode' },
+        type: { summary: 'Text of error' },
         defaultValue: { summary: 'Error' },
       },
     },
   },
   args: {
-    children: 'Error',
+    text: 'Error',
     size: ErrorSize.md,
   },
 };

--- a/packages/react/ds/src/error-text/error-text.tsx
+++ b/packages/react/ds/src/error-text/error-text.tsx
@@ -10,11 +10,13 @@ export enum ErrorSize {
 // Extend `React.HTMLAttributes<HTMLParagraphElement>` so that
 // the component can accept all the standard attributes and events that a `<p>` element can handle.
 export type ErrorTextProps = React.HTMLAttributes<HTMLParagraphElement> & {
+  text: string;
   size?: ErrorSize;
   className?: string;
 };
 
 export const ErrorText: React.FC<ErrorTextProps> = ({
+  text,
   className,
   size = ErrorSize.md,
   ...props
@@ -26,7 +28,7 @@ export const ErrorText: React.FC<ErrorTextProps> = ({
       className={`gi-font-bold gi-leading-5 gi-text-red-600 gi-clear-both gi-block gi-mb-[14px] gi-mt-0 ${className}`}
       {...props}
     >
-      {props.children}
+      {text}
     </Text>
   );
 };

--- a/packages/react/ds/src/file-upload/file-upload.stories.tsx
+++ b/packages/react/ds/src/file-upload/file-upload.stories.tsx
@@ -53,14 +53,14 @@ export const Default: Story = {
   args: {
     id: 'file-upload-id',
     label: {
-      children: 'Upload File',
+      text: 'Upload File',
       htmlFor: 'file-upload-id',
     },
     hint: {
-      children: '',
+      text: '',
     },
     error: {
-      children: '',
+      text: '',
     },
   },
 };
@@ -69,11 +69,11 @@ export const WithLabelAndHint: Story = {
   args: {
     id: 'file-upload-id',
     label: {
-      children: 'Upload File',
+      text: 'Upload File',
       htmlFor: 'file-upload-id',
     },
     hint: {
-      children: 'Hint: This is a helpful hint.',
+      text: 'Hint: This is a helpful hint.',
     },
   },
 };
@@ -82,11 +82,11 @@ export const WithLabelAndError: Story = {
   args: {
     id: 'file-upload-id',
     label: {
-      children: 'Upload File',
+      text: 'Upload File',
       htmlFor: 'file-upload-id',
     },
     error: {
-      children: 'Error: File must be smaller than 5MB.',
+      text: 'Error: File must be smaller than 5MB.',
     },
   },
 };

--- a/packages/react/ds/src/file-upload/file-upload.tsx
+++ b/packages/react/ds/src/file-upload/file-upload.tsx
@@ -14,23 +14,19 @@ export type FileUploadProps = React.InputHTMLAttributes<HTMLInputElement> & {
 // Use React.forwardRef to support refs properly
 export const FileUpload = React.forwardRef<HTMLInputElement, FileUploadProps>(
   ({ label, hint, error, id, ...props }, ref) => {
-    const hasError = error?.children;
-    const hasHint = hint?.children;
-    const hasLabel = label?.children;
-
     return (
       <div
-        className={`gi-pt-2 gi-mb-4 ${hasError ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
+        className={`gi-pt-2 gi-mb-4 ${error?.text ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
       >
-        {hasLabel && (
-          <Label size={label.size} htmlFor={id}>
+        {label?.text && (
+          <Label text={label.text} size={label.size} htmlFor={id}>
             {label.children}
           </Label>
         )}
 
-        {hasHint && <HintText size={hint.size}>{hint.children}</HintText>}
+        {hint?.text && <HintText text={hint.text} size={hint.size} />}
 
-        {hasError && <ErrorText size={error.size}>{error.children}</ErrorText>}
+        {error?.text && <ErrorText text={error.text} size={error.size} />}
 
         <input
           id={id}

--- a/packages/react/ds/src/hint-text/hint-text.stories.tsx
+++ b/packages/react/ds/src/hint-text/hint-text.stories.tsx
@@ -28,17 +28,17 @@ export const Default: Story = {
         defaultValue: { summary: HintSize.md },
       },
     },
-    children: {
+    text: {
       control: 'text',
       table: {
         category: 'Content',
-        type: { summary: 'React.ReactNode' },
+        type: { summary: 'text of hint' },
         defaultValue: { summary: 'Hint' },
       },
     },
   },
   args: {
-    children: 'Hint',
+    text: 'Hint',
     size: HintSize.md,
   },
 };

--- a/packages/react/ds/src/hint-text/hint-text.tsx
+++ b/packages/react/ds/src/hint-text/hint-text.tsx
@@ -10,12 +10,14 @@ export enum HintSize {
 // Extend `React.InputHTMLAttributes<HTMLInputElement>` so that
 // the component can accept all the standard attributes and events that an `<input>` element can handle.
 export type HintTextProps = React.HTMLAttributes<HTMLInputElement> & {
+  text: string;
   size?: HintSize;
   className?: string;
 };
 
 // Use React.forwardRef to support refs properly
 export const HintText: React.FC<HintTextProps> = ({
+  text,
   className,
   size,
   ...props
@@ -26,7 +28,7 @@ export const HintText: React.FC<HintTextProps> = ({
       className={`gi-font-normal gi-leading-5 gi-text-gray-700 gi-mb-[10px] ${className}`}
       {...props}
     >
-      {props.children}
+      {text}
     </Text>
   );
 };

--- a/packages/react/ds/src/label/label.stories.tsx
+++ b/packages/react/ds/src/label/label.stories.tsx
@@ -43,11 +43,11 @@ export const Default: Story = {
         defaultValue: { summary: '-' },
       },
     },
-    children: {
+    text: {
       control: 'text',
       table: {
         category: 'Content',
-        type: { summary: 'React.ReactNode' },
+        type: { summary: 'text for label' },
         defaultValue: { summary: 'Label' },
       },
     },
@@ -55,6 +55,6 @@ export const Default: Story = {
   args: {
     htmlFor: 'input-id',
     size: LabelSize.md,
-    children: 'Label',
+    text: 'Label',
   },
 };

--- a/packages/react/ds/src/label/label.tsx
+++ b/packages/react/ds/src/label/label.tsx
@@ -8,12 +8,13 @@ export enum LabelSize {
 
 // Extend `React.LabelHTMLAttributes<HTMLLabelElement>` for correct label attributes
 export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement> & {
+  text: string;
   size?: LabelSize;
 };
 
 // Use React.forwardRef to support refs properly
 export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
-  ({ size = LabelSize.md, htmlFor, ...props }, ref) => {
+  ({ text, size = LabelSize.md, htmlFor, ...props }, ref) => {
     return (
       <label
         className={`gi-text-${size} gi-leading-5 gi-mb-1 gi-block`}
@@ -21,7 +22,7 @@ export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
         htmlFor={htmlFor}
         {...props}
       >
-        {props.children}
+        {text}
       </label>
     );
   },

--- a/packages/react/ds/src/select/select.stories.ts
+++ b/packages/react/ds/src/select/select.stories.ts
@@ -63,13 +63,13 @@ export const Default: Story = {
   args: {
     id: 'unique-id',
     label: {
-      content: 'Label',
+      text: 'Label',
     },
     hint: {
-      content: '',
+      text: '',
     },
     error: {
-      content: '',
+      text: '',
     },
     options: [
       {
@@ -92,10 +92,10 @@ export const withHint: Story = {
   args: {
     id: 'unique-id',
     label: {
-      content: 'Default Select',
+      text: 'Default Select',
     },
     hint: {
-      content: 'This can be different to where you went before',
+      text: 'This can be different to where you went before',
     },
     options: [
       {
@@ -118,10 +118,10 @@ export const withError: Story = {
   args: {
     id: 'unique-id',
     label: {
-      content: 'Default Select',
+      text: 'Default Select',
     },
     error: {
-      content: 'Error message',
+      text: 'Error message',
     },
     options: [
       {
@@ -164,7 +164,7 @@ export const withGroups: Story = {
   args: {
     id: 'unique-id',
     label: {
-      content: 'Default Select',
+      text: 'Default Select',
     },
     options: [
       {

--- a/packages/react/ds/src/select/select.tsx
+++ b/packages/react/ds/src/select/select.tsx
@@ -23,16 +23,14 @@ type SelectProps = {
 };
 
 export function Select({ id, label, options, hint, error }: SelectProps) {
-  const ariaLabel = label?.content || id;
+  const ariaLabel = label?.text || id;
   return (
     <div>
-      {label && (
-        <Label htmlFor={id} size={label.size}>
-          {label.content}
-        </Label>
+      {label?.text && (
+        <Label text={label.text} htmlFor={id} size={label.size} />
       )}
-      {hint && <HintText size={hint.size}>{hint.content}</HintText>}
-      {error && <ErrorText size={error.size}>{error.content}</ErrorText>}
+      {hint && <HintText text={hint.text} size={hint.size} />}
+      {error && <ErrorText text={error.text} size={error.size} />}
       <select
         className="focus:gi-outline focus:gi-outline-[3px] focus:gi-outline-yellow-400 focus:gi-outline-offset-0 gi-p-1.5 gi-border-black gi-border-[3px] gi-border-solid gi-min-w-56 gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg"
         id={ariaLabel}

--- a/packages/react/ds/src/text-input/text-input.stories.tsx
+++ b/packages/react/ds/src/text-input/text-input.stories.tsx
@@ -94,14 +94,14 @@ export const Default: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Input Label',
+      text: 'Input Label',
       htmlFor: 'text-input-id',
     },
     hint: {
-      children: '',
+      text: '',
     },
     error: {
-      children: '',
+      text: '',
     },
   },
 };
@@ -110,11 +110,11 @@ export const WithLabelAndHint: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'text-input-id',
     },
     hint: {
-      children: 'Hint: This is a helpful hint.',
+      text: 'Hint: This is a helpful hint.',
     },
   },
 };
@@ -123,11 +123,11 @@ export const WithLabelAndError: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'text-input-id',
     },
     error: {
-      children: 'Error: Please correct this issue.',
+      text: 'Error: Please correct this issue.',
     },
   },
 };
@@ -136,14 +136,14 @@ export const WithLabelHintAndError: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'text-input-id',
     },
     hint: {
-      children: 'Hint: This is a helpful hint.',
+      text: 'Hint: This is a helpful hint.',
     },
     error: {
-      children: 'Error: Please correct this issue.',
+      text: 'Error: Please correct this issue.',
     },
     suffix: 'KG',
   },
@@ -153,7 +153,7 @@ export const WithLabelAndPrefixSuffix: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'text-input-id',
     },
     prefix: 'kg',
@@ -165,7 +165,7 @@ export const HalfFluid: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Half Fluid Input',
+      text: 'Half Fluid Input',
       htmlFor: 'text-input-id',
     },
     halfFluid: true,
@@ -176,7 +176,7 @@ export const FullFluid: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: 'Full Fluid Input',
+      text: 'Full Fluid Input',
       htmlFor: 'text-input-id',
     },
     fullFluid: true,
@@ -187,7 +187,7 @@ export const CharacterWidth: Story = {
   args: {
     id: 'text-input-id',
     label: {
-      children: '4 characters width',
+      text: '4 characters width',
       htmlFor: 'text-input-id',
     },
     characterWidth: 4,

--- a/packages/react/ds/src/text-input/text-input.tsx
+++ b/packages/react/ds/src/text-input/text-input.tsx
@@ -46,23 +46,17 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       widthClass = 'gi-w-1/2';
     }
 
-    const hasError = error?.children;
-    const hasHint = hint?.children;
-    const hasLabel = label?.children;
-
     return (
       <div
-        className={`gi-pt-2 gi-mb-4 ${hasError ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
+        className={`gi-pt-2 gi-mb-4 ${error?.text ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
       >
-        {hasLabel && (
-          <Label size={label.size} htmlFor={id}>
-            {label.children}
-          </Label>
+        {label?.text && (
+          <Label text={label.text} size={label.size} htmlFor={id} />
         )}
 
-        {hasHint && <HintText size={hint.size}>{hint.children}</HintText>}
+        {hint?.text && <HintText text={hint.text} size={hint.size} />}
 
-        {hasError && <ErrorText size={error.size}>{error.children}</ErrorText>}
+        {error?.text && <ErrorText text={error.text} size={error.size} />}
 
         <div className="gi-flex gi-items-center">
           {prefix && (
@@ -73,7 +67,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
           <input
             id={id}
             style={widthStyle}
-            className={`${hasError ? 'gi-border-red-600' : 'gi-border-gray-950'} ${widthClass} gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-h-10 gi-mt-0 gi-p-1 focus:gi-outline focus:gi-outline-[3px] focus:gi-border-lg focus:gi-border-gray-950 focus:gi-outline-yellow-400 focus:gi-outline-offset-0 gi-z-1 xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5`}
+            className={`${error?.text ? 'gi-border-red-600' : 'gi-border-gray-950'} ${widthClass} gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-h-10 gi-mt-0 gi-p-1 focus:gi-outline focus:gi-outline-[3px] focus:gi-border-lg focus:gi-border-gray-950 focus:gi-outline-yellow-400 focus:gi-outline-offset-0 gi-z-1 xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5`}
             ref={ref}
             {...props}
           />

--- a/packages/react/ds/src/textarea/textarea.stories.tsx
+++ b/packages/react/ds/src/textarea/textarea.stories.tsx
@@ -86,14 +86,14 @@ export const Default: Story = {
     cols: 100,
     id: 'textarea-id',
     label: {
-      children: 'Textarea Label',
+      text: 'Textarea Label',
       htmlFor: 'textarea-id',
     },
     error: {
-      children: '',
+      text: '',
     },
     hint: {
-      children: '',
+      text: '',
     },
   },
 };
@@ -102,11 +102,11 @@ export const WithLabelAndHint: Story = {
   args: {
     id: 'textarea-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'textarea-id',
     },
     hint: {
-      children: 'Hint: This is a helpful hint.',
+      text: 'Hint: This is a helpful hint.',
     },
     rows: 4,
     cols: 100,
@@ -117,11 +117,11 @@ export const WithLabelAndError: Story = {
   args: {
     id: 'textarea-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'textarea-id',
     },
     error: {
-      children: 'Error: Please correct this issue.',
+      text: 'Error: Please correct this issue.',
     },
   },
 };
@@ -130,14 +130,14 @@ export const WithLabelHintAndError: Story = {
   args: {
     id: 'textarea-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'textarea-id',
     },
     hint: {
-      children: 'Hint: This is a helpful hint.',
+      text: 'Hint: This is a helpful hint.',
     },
     error: {
-      children: 'Error: Please correct this issue.',
+      text: 'Error: Please correct this issue.',
     },
   },
 };
@@ -146,7 +146,7 @@ export const CustomRowsAndColumns: Story = {
   args: {
     id: 'textarea-id',
     label: {
-      children: 'Label',
+      text: 'Label',
       htmlFor: 'textarea-id',
     },
     rows: 6,

--- a/packages/react/ds/src/textarea/textarea.tsx
+++ b/packages/react/ds/src/textarea/textarea.tsx
@@ -31,30 +31,24 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     ref,
   ) => {
-    const hasError = error?.children;
-    const hasHint = hint?.children;
-    const hasLabel = label?.children;
-
     return (
       <div
-        className={`gi-pt-2 gi-mb-4 ${hasError ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
+        className={`gi-pt-2 gi-mb-4 ${error?.text ? 'gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600' : ''}`}
       >
-        {hasLabel && (
-          <Label size={label.size} htmlFor={id}>
-            {label.children}
-          </Label>
+        {label?.text && (
+          <Label text={label.text} size={label.size} htmlFor={id} />
         )}
 
-        {hasHint && <HintText size={hint.size}>{hint.children}</HintText>}
+        {hint?.text && <HintText text={hint.text} size={hint.size} />}
 
-        {hasError && <ErrorText size={error.size}>{error.children}</ErrorText>}
+        {error?.text && <ErrorText text={error.text} size={error.size} />}
         <div className="gi-flex gi-items-center">
           <textarea
             id={id}
             rows={rows}
             cols={cols}
             autoComplete={autoComplete}
-            className={`${hasError ? 'gi-border-red-600' : 'gi-border-gray-950'} gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-p-1 focus:gi-outline focus:gi-outline-[3px] focus:gi-border-lg focus:gi-border-gray-950 focus:gi-outline-yellow-400 focus:gi-outline-offset-0 xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10`}
+            className={`${error?.text ? 'gi-border-red-600' : 'gi-border-gray-950'} gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-p-1 focus:gi-outline focus:gi-outline-[3px] focus:gi-border-lg focus:gi-border-gray-950 focus:gi-outline-yellow-400 focus:gi-outline-offset-0 xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10`}
             ref={ref}
             {...props}
           />


### PR DESCRIPTION
As part of [21977](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/21977) I've refactored the `children` into a `text` prop so now it accepts `string` instead of a react node.