### PR TITLE
fix: add server action support

### DIFF
--- a/packages/react/ds/src/header/components/header-menu.tsx
+++ b/packages/react/ds/src/header/components/header-menu.tsx
@@ -11,7 +11,8 @@ type HeaderMenuProps = {
     label: string;
   }[];
   searchProps?: {
-    action: string;
+    action?: string;
+    serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     label?: string;
     icon?: IconId;
   };

--- a/packages/react/ds/src/header/components/header-search.tsx
+++ b/packages/react/ds/src/header/components/header-search.tsx
@@ -7,7 +7,6 @@ function HeaderSearch({
   icon = 'search',
 }: {
   action?: string;
-  // Temporary solution to include the usage of Server Actions, as the types of react allow only strings | undefined. The types/react package will eventually get allow this and a more permanent solution will be implemented
   serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   className?: string;
   icon?: IconId;

--- a/packages/react/ds/src/header/components/header-search.tsx
+++ b/packages/react/ds/src/header/components/header-search.tsx
@@ -7,6 +7,7 @@ function HeaderSearch({
   icon = 'search',
 }: {
   action?: string;
+  // Temporary solution to include the usage of Server Actions, as the types of react allow only strings | undefined. The types/react package will eventually get allow this and a more permanent solution will be implemented
   serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   className?: string;
   icon?: IconId;

--- a/packages/react/ds/src/header/components/header-search.tsx
+++ b/packages/react/ds/src/header/components/header-search.tsx
@@ -2,20 +2,23 @@ import { Icon, IconId } from '../../icon/icon.js';
 
 function HeaderSearch({
   action,
+  serverAction,
   className,
   icon = 'search',
 }: {
-  action: string;
+  action?: string;
+  serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   className?: string;
   icon?: IconId;
 }) {
+  const ActionType = action || serverAction;
   return (
     <div
       id="SearchContainer"
       className={`gi-flex gi-h-0 gi-bg-gray-50 gi-overflow-hidden gi-px-4 xs:gi-px-8 ${className}`}
     >
       <div className="sm:gi-w-3/6 gi-w-full gi-flex gi-mx-auto gi-flex-col gi-my-8">
-        <form action={action}>
+        <form action={ActionType}>
           <label htmlFor="search" className="gi-text-md gi-font-bold gi-mb-4">
             Enter search term
           </label>

--- a/packages/react/ds/src/header/header.tsx
+++ b/packages/react/ds/src/header/header.tsx
@@ -13,7 +13,8 @@ export type HeaderProps = {
   };
   tools?: {
     search?: {
-      action: string;
+      action?: string;
+      serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
       label?: string;
       icon?: IconId;
     };

--- a/packages/react/ds/src/header/header.tsx
+++ b/packages/react/ds/src/header/header.tsx
@@ -14,6 +14,7 @@ export type HeaderProps = {
   tools?: {
     search?: {
       action?: string;
+      // Temporary solution to include the usage of Server Actions, as the types of react allow only strings | undefined. The types/react package will eventually get allow this and a more permanent solution will be implemented
       serverAction?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
       label?: string;
       icon?: IconId;


### PR DESCRIPTION
Following a conversation with Ludwig and Andrea, a issue has come up in regards to using Server Actions in the Search component of the Header. Since react/types does not support that we have come up with a temporary workaround until React catches up