### PR TITLE
chore: update tag types to sync with figma values

### DIFF
--- a/apps/docs/content/3-components/2-library/38-tag.mdx
+++ b/apps/docs/content/3-components/2-library/38-tag.mdx
@@ -12,7 +12,7 @@ status: in-development
 Tags are used to visually categorise content. They can indicate the status of an item or represent a category of information. By default, tags have a blue background and text color.
 
 <Paragraph>
-  <Tag text="Completed" type="blue" />
+  <Tag text="Completed" type="info" />
 </Paragraph>
 
 <Tabs id="tab1">
@@ -23,7 +23,7 @@ Tags are used to visually categorise content. They can indicate the status of an
   </TabList>
   <TabPanel value="tab11">        
     ```html
-    <strong class="gi-tag gi-tag-blue">
+    <strong class="gi-tag gi-tag-info">
       Completed
     </strong>
     ```
@@ -32,7 +32,7 @@ Tags are used to visually categorise content. They can indicate the status of an
     ```html
     {{ govieTag({
       "text": "Completed",
-      "type": "blue"
+      "type": "info"
     }) }}
     ```
   </TabPanel>
@@ -42,7 +42,7 @@ Tags are used to visually categorise content. They can indicate the status of an
 
     <Tag
       text="Completed"
-      type="blue"
+      type="info"
     />
     ```
 

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -101,25 +101,26 @@
 /* Tag */
 
 .gi-tag {
-  @apply gi-rounded-md gi-border-xs gi-font-normal gi-py-0 gi-px-2 gi-inline-flex gi-justify-center gi-items-center;
+  @apply gi-rounded-sm gi-border-xs gi-font-bold gi-leading-6
+	 gi-py-0 gi-px-2 gi-inline-flex gi-justify-center gi-items-center;
 }
 
-.gi-tag-blue {
-  @apply gi-bg-blue-50 gi-border-blue-100 gi-text-blue-700;
-}
-
-.gi-tag-gray {
+.gi-tag-default {
   @apply gi-bg-gray-50 gi-border-gray-200 gi-text-gray-700;
 }
 
-.gi-tag-green {
+.gi-tag-info {
+  @apply gi-bg-blue-50 gi-border-blue-100 gi-text-blue-700;
+}
+
+.gi-tag-success {
   @apply gi-bg-green-50 gi-border-green-100 gi-text-green-700;
 }
 
-.gi-tag-yellow {
+.gi-tag-warning {
   @apply gi-bg-yellow-50 gi-border-yellow-300 gi-text-yellow-700;
 }
 
-.gi-tag-red {
+.gi-tag-error {
   @apply gi-bg-red-50 gi-border-red-100 gi-text-red-700;
 }

--- a/packages/html/ds/src/tag/tag.html
+++ b/packages/html/ds/src/tag/tag.html
@@ -2,13 +2,13 @@
   {# Mapping tag type to classes similar to React's tagClass structure #}
   {% macro getClasses(type) %}
     {% set tagClasses = {
-      'blue': 'gi-tag-blue',
-      'gray': 'gi-tag-gray',
-      'green': 'gi-tag-green',
-      'yellow': 'gi-tag-yellow',
-      'red': 'gi-tag-red'
+      'default': 'gi-tag-default',
+      'info': 'gi-tag-info',
+      'success': 'gi-tag-success',
+      'warning': 'gi-tag-warning',
+      'error': 'gi-tag-error'
     } %}
-    {{ tagClasses[type | default('blue')] }}
+    {{ tagClasses[type | default('info')] }}
   {% endmacro %}
 
   <strong class="gi-tag {{ getClasses(props.type) | trim }}">

--- a/packages/html/ds/src/tag/tag.schema.ts
+++ b/packages/html/ds/src/tag/tag.schema.ts
@@ -1,11 +1,11 @@
 import * as zod from 'zod';
 
 export enum TagType {
-  blue = 'blue',
-  gray = 'gray',
-  green = 'green',
-  yellow = 'yellow',
-  red = 'red',
+  default = 'default',
+  info = 'info',
+  success = 'success',
+  warning = 'warning',
+  error = 'error',
 }
 
 export const tagSchema = zod.object({

--- a/packages/html/ds/src/tag/tag.stories.ts
+++ b/packages/html/ds/src/tag/tag.stories.ts
@@ -53,6 +53,6 @@ export const Default: Story = {
   },
   args: {
     text: 'Completed',
-    type: TagType.blue,
+    type: TagType.info,
   },
 };

--- a/packages/html/ds/src/tag/tag.test.ts
+++ b/packages/html/ds/src/tag/tag.test.ts
@@ -12,7 +12,7 @@ describe('govieTag', () => {
   it('should render a tag with the correct content', () => {
     const screen = renderTag({
       text: 'This is a tag',
-      type: TagType.blue,
+      type: TagType.default,
     });
     const tagElement = screen.getByText('This is a tag');
     expect(tagElement).toBeTruthy();
@@ -20,11 +20,11 @@ describe('govieTag', () => {
   });
 
   const tagTypeClasses = {
-    [TagType.blue]: 'gi-tag-blue',
-    [TagType.gray]: 'gi-tag-gray',
-    [TagType.green]: 'gi-tag-green',
-    [TagType.yellow]: 'gi-tag-yellow',
-    [TagType.red]: 'gi-tag-red',
+    [TagType.info]: 'gi-tag-info',
+    [TagType.default]: 'gi-tag-default',
+    [TagType.success]: 'gi-tag-success',
+    [TagType.warning]: 'gi-tag-warning',
+    [TagType.error]: 'gi-tag-error',
   };
 
   describe.each(Object.entries(tagTypeClasses))(
@@ -46,7 +46,7 @@ describe('govieTag', () => {
   it('should pass axe accessibility tests', async () => {
     const screen = renderTag({
       text: 'Accessible tag',
-      type: TagType.blue,
+      type: TagType.info,
     });
 
     await screen.axe();

--- a/packages/react/ds/src/tag/tag.stories.tsx
+++ b/packages/react/ds/src/tag/tag.stories.tsx
@@ -46,6 +46,6 @@ export const Default: Story = {
   },
   args: {
     text: 'Completed',
-    type: TagType.blue,
+    type: TagType.info,
   },
 };

--- a/packages/react/ds/src/tag/tag.tsx
+++ b/packages/react/ds/src/tag/tag.tsx
@@ -1,9 +1,9 @@
 export enum TagType {
-  blue = 'blue',
-  gray = 'gray',
-  green = 'green',
-  yellow = 'yellow',
-  red = 'red',
+  default = 'default',
+  info = 'info',
+  success = 'success',
+  warning = 'warning',
+  error = 'error',
 }
 
 export type TagProps = {
@@ -12,14 +12,14 @@ export type TagProps = {
 };
 
 const tagClass = {
-  [TagType.blue]: 'gi-tag-blue',
-  [TagType.gray]: 'gi-tag-gray',
-  [TagType.green]: 'gi-tag-green',
-  [TagType.yellow]: 'gi-tag-yellow',
-  [TagType.red]: 'gi-tag-red',
+  [TagType.default]: 'gi-tag-default',
+  [TagType.info]: 'gi-tag-info',
+  [TagType.success]: 'gi-tag-success',
+  [TagType.warning]: 'gi-tag-warning',
+  [TagType.error]: 'gi-tag-error',
 };
 
-export const Tag = ({ text, type = TagType.blue }: TagProps) => {
+export const Tag = ({ text, type = TagType.default }: TagProps) => {
   return <strong className={`gi-tag ${tagClass[type]}`}>{text}</strong>;
 };
 


### PR DESCRIPTION
Updated tag types with the values from figma.

- default as `gray`.
- info as `blue`.
- success as `green`.
- yellow as `warning`.
- red as `error`.

Testing:
![Screenshot 2024-10-07 at 12 45 21](https://github.com/user-attachments/assets/6f79356e-789d-4931-82cf-dcebf7134589)
