### PR TITLE
fix: match the id of select with for attr

### DIFF
--- a/packages/html/ds/src/select/select.html
+++ b/packages/html/ds/src/select/select.html
@@ -41,7 +41,7 @@
       }}
     {% endif %}
     <select
-      id="{{ ariaLabel }}"
+      id="{{ props.id }}"
       aria-label="{{ ariaLabel }}"
       class="focus:gi-outline focus:gi-outline-[3px] focus:gi-outline-yellow-400 focus:gi-outline-offset-0 gi-p-1.5 gi-border-black gi-border-[3px] gi-border-solid gi-min-w-56 gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg {{ marginTop }}"
     >

--- a/packages/react/ds/src/select/select.tsx
+++ b/packages/react/ds/src/select/select.tsx
@@ -51,7 +51,7 @@ export function Select({ id, label, options, hint, error }: SelectProps) {
           xs:gi-text-sm
           md:gi-text-md
           lg:gi-text-lg"
-        id={ariaLabel}
+        id={id}
         aria-label={ariaLabel}
       >
         {options.map((option) => {


### PR DESCRIPTION
Minor fix to always match the `id` attr of the `select` with the `for` attr of the `label`