### PR TITLE
fix: html header in jinja

### DIFF
--- a/examples/wagtail/core/jinja/vars.jinja
+++ b/examples/wagtail/core/jinja/vars.jinja
@@ -41,37 +41,44 @@
 %}
 
 {% set HeaderProps = {
-  "logo": { "href": '/home' },
-  "tools": {
-    "search": {
-      "action": '/search_page',
-      "noJsSearchLink": '/search',
+    "logo": { "href": '/home' },
+    "tools": {
+      "search": {
+        "action": '/search_page',
+        "label": 'Search',
+      },
+      "items": [
+        {
+          "href": '/item1',
+          "label": 'Apps',
+          "icon": 'apps',
+        },
+      ],
+      "menu": {
+        "label": 'Menu',
+      },
     },
-    "menu": {
-      "noJsMenuLink": '/menu',
-    },
-  },
-  "navLinks": [
-    {
-      "href": '#',
-      "label": 'News',
-    },
-    {
-      "href": '#',
-      "label": 'Departments',
-    },
-    {
-      "href": '#',
-      "label": 'Services',
-    },
-  ],
-  "languages": [
-    {
-      "href": '#',
-      "label": 'Gaeilge',
-    },
-  ],
-}
+    "navLinks": [
+      {
+        "href": '#',
+        "label": 'News',
+      },
+      {
+        "href": '#',
+        "label": 'Departments',
+      },
+      {
+        "href": '#',
+        "label": 'Services',
+      },
+    ],
+    "languages": [
+      {
+        "href": '#',
+        "label": 'Gaeilge',
+      },
+    ],
+  }
 %}
 
 {% set SelectProps = {

--- a/packages/html/ds/src/header/header.html
+++ b/packages/html/ds/src/header/header.html
@@ -90,7 +90,7 @@
           </div>
         </label>
       {% endif %}
-      {% for item in props.tools.items %}
+      {% for item in props['tools']['items'] %}
         <a class="{{ toolItemClassNames }}" href="{{ item.href }}">
           <span className="label">{{ item.label }}</span>
           {{ govieIcon({"icon": item.icon }) }}


### PR DESCRIPTION
Seems that in Jinja, we can't access the array with the `.` dot notation.
Happened already with the tabs.