### PR TITLE
chore: expose icon type to accept string

### DIFF
--- a/packages/html/ds/src/icon/icon.schema.ts
+++ b/packages/html/ds/src/icon/icon.schema.ts
@@ -21,9 +21,12 @@ export enum IconSize {
 
 export const iconSchema = zod.object({
   icon: zod
-    .nativeEnum(IconId, {
-      description: 'Specifies the Icon name to show',
-    })
+    .union([
+      zod.nativeEnum(IconId, {
+        description: 'Specifies the Icon name to show',
+      }),
+      zod.string().min(1, { message: 'Custom string for any other icon' }),
+    ])
     .optional(),
   size: zod
     .nativeEnum(IconSize, {

--- a/packages/react/ds/src/icon/icon.tsx
+++ b/packages/react/ds/src/icon/icon.tsx
@@ -24,7 +24,7 @@ export type IconColor = 'default' | 'disabled';
 export type IconVariant = 'default' | 'outlined';
 
 export type IconPropTypes = {
-  icon: IconId;
+  icon: IconId | string;
   size?: IconSize;
   variant?: IconVariant;
   color?: IconColor;


### PR DESCRIPTION
- Icon Id will accept other strings as well (if the user wishes to use a different icon set apart from the DS).

Testing on VS Code:
![Screenshot 2024-10-22 at 13 24 56](https://github.com/user-attachments/assets/25be5c08-b5e8-4268-a1d4-0f3660c7aaef)
![Screenshot 2024-10-22 at 13 25 02](https://github.com/user-attachments/assets/b3800384-dbda-44ae-a722-ba76be825231)
