### PR TITLE
chore: Adding pseudo button states in storybook for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@storybook/react-vite": "8.3.6",
     "@storybook/test": "8.3.6",
     "@storybook/test-runner": "0.19.1",
+    "@tsconfig/node22": "^22.0.0",
     "@types/node": "22.8.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -56,16 +57,16 @@
     "http-server": "^14.1.1",
     "nx": "^19.5.6",
     "playwright": "^1.48.1",
+    "prettier": "^3.3.3",
     "storybook": "8.3.6",
+    "storybook-addon-pseudo-states": "^4.0.2",
     "tailwindcss": "3.4.14",
     "tsup": "^8.2.5",
+    "tsx": "^4.19.2",
     "typescript": "5.6.3",
     "vite": "5.4.10",
     "vitest": "2.1.3",
-    "wait-on": "^8.0.1",
-    "@tsconfig/node22": "^22.0.0",
-    "prettier": "^3.3.3",
-    "tsx": "^4.19.2"
+    "wait-on": "^8.0.1"
   },
   "peerDependencies": {
     "@vitest/spy": "2.1.3"

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -36,24 +36,30 @@ input[type='text'] {
 
 /* Error state */
 .gi-error-state {
-  @apply gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600
+  @apply gi-px-4 gi-border-solid gi-border-l-lg gi-border-red-600;
 }
 
 /* End of Error state */
 
+/* General Input disable state */
+.gi-input-disabled-state {
+  @apply disabled:gi-bg-gray-200 disabled:gi-border-gray-400;
+}
+/* General Input disable state */
+
 /* Blockquote */
 .gi-blockquote {
-  @apply gi-my-6 gi-p-4 gi-border-l-2xl gi-border-gray-400 gi-text-sm md:gi-text-md
+  @apply gi-my-6 gi-p-4 gi-border-l-2xl gi-border-gray-400 gi-text-sm md:gi-text-md;
 }
 
 /* End Blockquote */
 
 /* Select */
 .gi-select {
-  @apply gi-focus-state-outline gi-p-1.5 gi-border-black gi-border-[3px] gi-border-solid gi-min-w-56 gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply gi-focus-state-outline gi-p-1.5 gi-border-black gi-border-[3px] gi-border-solid gi-min-w-56 gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 .gi-select-option {
-  @apply gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply gi-font-primary xs:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 
 /* End of Select */
@@ -61,19 +67,19 @@ input[type='text'] {
 /* Text Input */
 
 .gi-text-input-container {
-  @apply gi-pt-2 gi-mb-4
+  @apply gi-pt-2 gi-mb-4;
 }
 .gi-text-input-container-inner {
-  @apply gi-flex gi-items-center
+  @apply gi-flex gi-items-center;
 }
 .gi-text-input-prefix {
-  @apply xs:gi-text-md gi-text-sm gi-leading-5 xs:!gi-leading-5 gi-bg-gray-50 gi-inline-block gi-flex-[0_0_auto] gi-text-center gi-whitespace-nowrap gi-cursor-default gi-px-2 gi-py-2 gi-border-l-sm gi-border-t-sm gi-border-b-sm gi-border-solid gi-border-gray-950 gi-min-w-10 gi-h-10
+  @apply xs:gi-text-md gi-text-sm gi-leading-5 xs:!gi-leading-5 gi-bg-gray-50 gi-inline-block gi-flex-[0_0_auto] gi-text-center gi-whitespace-nowrap gi-cursor-default gi-px-2 gi-py-2 gi-border-l-sm gi-border-t-sm gi-border-b-sm gi-border-solid gi-border-gray-950 gi-min-w-10 gi-h-10;
 }
 .gi-text-input-suffix {
-  @apply xs:gi-text-md gi-text-sm gi-leading-5 xs:!gi-leading-5 gi-bg-gray-50 gi-inline-block gi-flex-[0_0_auto] gi-text-center gi-whitespace-nowrap gi-cursor-default gi-px-2 gi-py-2 gi-border-r-sm gi-border-t-sm gi-border-b-sm gi-border-solid gi-border-gray-950 gi-min-w-10 gi-h-10
+  @apply xs:gi-text-md gi-text-sm gi-leading-5 xs:!gi-leading-5 gi-bg-gray-50 gi-inline-block gi-flex-[0_0_auto] gi-text-center gi-whitespace-nowrap gi-cursor-default gi-px-2 gi-py-2 gi-border-r-sm gi-border-t-sm gi-border-b-sm gi-border-solid gi-border-gray-950 gi-min-w-10 gi-h-10;
 }
 .gi-text-input {
-  @apply gi-focus-state-outline gi-focus-state-border gi-flex-initial  gi-border-sm gi-border-solid gi-box-border gi-h-10 gi-mt-0 gi-p-1 gi-z-1 xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5
+  @apply gi-focus-state-outline gi-focus-state-border gi-flex-initial  gi-border-sm gi-border-solid gi-box-border gi-h-10 gi-mt-0 gi-p-1 gi-z-1 xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5 gi-input-disabled-state;
 }
 
 /* End of Text Input */
@@ -81,32 +87,32 @@ input[type='text'] {
 /* Hint Text */
 
 .gi-hint-text-md {
-  @apply gi-text-md gi-mb-2
+  @apply gi-text-md gi-mb-2;
 }
 .gi-hint-text-sm {
-  @apply gi-text-sm gi-mb-1.5
+  @apply gi-text-sm gi-mb-1.5;
 }
 .gi-hint-text-lg {
-  @apply gi-text-lg gi-mb-2.5
+  @apply gi-text-lg gi-mb-2.5;
 }
 .gi-hint-text {
-  @apply gi-font-normal gi-text-gray-600
+  @apply gi-font-normal gi-text-gray-600;
 }
 
 /* End of Hint Text */
 
 /* Error Text */
 .gi-error-text-md {
-  @apply gi-text-md  gi-mb-3
+  @apply gi-text-md  gi-mb-3;
 }
 .gi-error-text-sm {
-  @apply gi-text-sm  gi-mb-2.5
+  @apply gi-text-sm  gi-mb-2.5;
 }
 .gi-error-text-lg {
-  @apply gi-text-lg  gi-mb-3.5
+  @apply gi-text-lg  gi-mb-3.5;
 }
 .gi-error-text {
-  @apply gi-font-bold gi-text-red-600
+  @apply gi-font-bold gi-text-red-600;
 }
 
 /* End of Error Text */
@@ -114,10 +120,10 @@ input[type='text'] {
 /* Phase banner */
 
 .gi-phase-banner-container {
-  @apply gi-flex gi-items-center gi-gap-2 gi-border-b-xs gi-py-2
+  @apply gi-flex gi-items-center gi-gap-2 gi-border-b-xs gi-py-2;
 }
 .gi-phase-banner {
-  @apply gi-text-white gi-tracking-wider gi-bg-blue-600 gi-px-2 gi-rounded
+  @apply gi-text-white gi-tracking-wider gi-bg-blue-600 gi-px-2 gi-rounded;
 }
 
 /* End of Phase banner */
@@ -125,43 +131,43 @@ input[type='text'] {
 /* Radio */
 
 .gi-radio-group-container {
-  @apply gi-flex
+  @apply gi-flex;
 }
 .gi-radio-group-error {
-  @apply gi-w-5 gi-border-l-[5px] gi-border-l-red-600 gi-border-solid
+  @apply gi-w-5 gi-border-l-[5px] gi-border-l-red-600 gi-border-solid;
 }
 .gi-radio-group-legend {
-  @apply sm:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply sm:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 .gi-radio-group-options-container {
-  @apply gi-flex gi-flex-col gi-gap-2.5
+  @apply gi-flex gi-flex-col gi-gap-2.5;
 }
 .gi-radio-group-options-inline {
-  @apply gi-flex gi-flex-row gi-gap-4
+  @apply gi-flex gi-flex-row gi-gap-4;
 }
 .gi-radio-group-options-stacked {
-  @apply gi-flex gi-flex-col gi-gap-2.5
+  @apply gi-flex gi-flex-col gi-gap-2.5;
 }
 .gi-radio-group-options-divider-text {
-  @apply gi-text-center xs:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply gi-text-center xs:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 .gi-radio-container {
-  @apply gi-flex gi-flex-col
+  @apply gi-flex gi-flex-col;
 }
 .gi-radio-input-container {
-  @apply gi-gap-4 gi-flex gi-items-center
+  @apply gi-gap-4 gi-flex gi-items-center;
 }
 .gi-radio-label {
-  @apply gi-cursor-pointer xs:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply gi-cursor-pointer xs:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 .gi-radio-conditional-divider-container {
-  @apply gi-flex gi-gap-4
+  @apply gi-flex gi-gap-4;
 }
 .gi-radio-conditional-divider-border-container {
-  @apply gi-h-full gi-flex gi-justify-center gi-mt-1.5
+  @apply gi-h-full gi-flex gi-justify-center gi-mt-1.5;
 }
 .gi-radio-conditional-divider-border {
-  @apply gi-h-full gi-w-1 gi-bg-gray-300
+  @apply gi-h-full gi-w-1 gi-bg-gray-300;
 }
 
 /* End of Radio */
@@ -169,17 +175,17 @@ input[type='text'] {
 /* Label */
 
 .gi-label {
-  @apply gi-mb-1 gi-block
+  @apply gi-mb-1 gi-block;
 }
 
 /* End of Label */
 
 /* File-upload */
 .gi-file-upload-container {
-  @apply gi-pt-2 gi-mb-4
+  @apply gi-pt-2 gi-mb-4;
 }
 .gi-file-upload-input {
-  @apply xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5 gi-p-[3px] gi-max-w-[100%] gi-border-transparent gi-flex-initial gi-ml-[-5px] gi-border-sm gi-border-solid gi-box-border gi-focus-state-outline gi-focus-state-border gi-z-1
+  @apply xs:gi-text-md gi-text-sm gi-leading-10 xs:!gi-leading-5 gi-p-[3px] gi-max-w-[100%] gi-border-transparent gi-flex-initial gi-ml-[-5px] gi-border-sm gi-border-solid gi-box-border gi-focus-state-outline gi-focus-state-border gi-z-1;
 }
 
 /* End of File-upload */
@@ -669,15 +675,15 @@ input[type='file' i] {
 
 .gi-textarea,
 .gi-textarea-error {
-  @apply gi-focus-state-outline focus:gi-shadow-[inset_0_0_0_1px] focus:gi-border-gray-950 gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-p-1  xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10 gi-border-gray-950;
+  @apply gi-focus-state-outline focus:gi-shadow-[inset_0_0_0_1px] focus:gi-border-gray-950 gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-p-1  xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10 gi-border-gray-950 gi-input-disabled-state;
 }
 
 .gi-textarea-layout-container {
-  @apply gi-pt-2 gi-mb-4
+  @apply gi-pt-2 gi-mb-4;
 }
 
 .gi-textarea-container {
-  @apply gi-flex gi-items-center
+  @apply gi-flex gi-items-center;
 }
 
 .gi-textarea-error {
@@ -687,60 +693,64 @@ input[type='file' i] {
 .gi-textarea-remaining-chars {
   @apply gi-mt-2;
 }
+
+.gi-textarea-disabled {
+  @apply gi-bg-gray-200 gi-border-gray-400;
+}
 /* TextArea */
 
 /* ComboBox */
 
 .gi-combobox-container {
- @apply gi-max-w-[400px] gi-border-t
+  @apply gi-max-w-[400px] gi-border-t;
 }
 .gi-combobox-toggle {
-  @apply gi-border-t-transparent gi-border-t-sm gi-relative gi-z-1 hover:gi-bg-gray-200 gi-border-b gi-px-2 gi-py-4 gi-flex gi-justify-between gi-cursor-pointer gi-w-full gi-focus-state-outline gi-focus-state-border-sm focus:gi-bg-gray-200
+  @apply gi-border-t-transparent gi-border-t-sm gi-relative gi-z-1 hover:gi-bg-gray-200 gi-border-b gi-px-2 gi-py-4 gi-flex gi-justify-between gi-cursor-pointer gi-w-full gi-focus-state-outline gi-focus-state-border-sm focus:gi-bg-gray-200;
 }
 .gi-combobox-toggle-open {
-  @apply gi-border-b-0
+  @apply gi-border-b-0;
 }
 .gi-combobox-toggle-content {
-  @apply gi-flex gi-gap-2
+  @apply gi-flex gi-gap-2;
 }
 .gi-combobox-toggle-content > p {
-  @apply gi-mb-0 gi-leading-[1.3]
+  @apply gi-mb-0 gi-leading-[1.3];
 }
 .gi-combobox-dropdown-container-open {
-  @apply gi-bg-gray-50 gi-relative gi-block gi-border-b
+  @apply gi-bg-gray-50 gi-relative gi-block gi-border-b;
 }
 .gi-combobox-search {
-  @apply gi-py-4 gi-px-3 gi-relative
+  @apply gi-py-4 gi-px-3 gi-relative;
 }
 .gi-combobox-search-input {
-  @apply gi-pt-0 gi-pb-0 gi-mb-0
+  @apply gi-pt-0 gi-pb-0 gi-mb-0;
 }
 .gi-combobox-search-input input {
-  @apply gi-pl-3
+  @apply gi-pl-3;
 }
 .gi-combobox-search-input input::placeholder {
-  @apply gi-text-gray-600
+  @apply gi-text-gray-600;
 }
 .gi-combobox-search-icon {
-  @apply gi-absolute gi-right-4 gi-top-5 gi-z-100 gi-cursor-pointer
+  @apply gi-absolute gi-right-4 gi-top-5 gi-z-100 gi-cursor-pointer;
 }
 .gi-combobox-checkbox-container {
-  @apply gi-h-64 gi-overflow-y-auto gi-overflow-x-hidden gi-pt-2
+  @apply gi-h-64 gi-overflow-y-auto gi-overflow-x-hidden gi-pt-2;
 }
 .gi-combobox-checkbox-container .gi-checkbox-container {
-  @apply gi-items-center
+  @apply gi-items-center;
 }
 .gi-combobox-checkbox-paragraph {
-  @apply gi-text-center gi-w-full !gi-max-w-none
+  @apply gi-text-center gi-w-full !gi-max-w-none;
 }
 .gi-combobox-checkbox {
-  @apply gi-px-3 hover:gi-bg-gray-200
+  @apply gi-px-3 hover:gi-bg-gray-200;
 }
 .gi-combobox-checkbox input {
-  @apply gi-min-w-6
+  @apply gi-min-w-6;
 }
 .gi-combobox-checkbox label {
-  @apply gi-w-full gi-py-2
+  @apply gi-w-full gi-py-2;
 }
 
 /* End of ComboBox */
@@ -748,25 +758,25 @@ input[type='file' i] {
 /* Checkbox group */
 
 .gi-checkbox-group-container {
-  @apply gi-flex
+  @apply gi-flex;
 }
 .gi-checkbox-group-error {
-  @apply gi-w-4 gi-border-l-lg gi-border-l-red-600 gi-border-solid
+  @apply gi-w-4 gi-border-l-lg gi-border-l-red-600 gi-border-solid;
 }
 .gi-checkbox-group-title {
-  @apply gi-mb-3.5 sm:gi-text-sm md:gi-text-md lg:gi-text-lg
+  @apply gi-mb-3.5 sm:gi-text-sm md:gi-text-md lg:gi-text-lg;
 }
 .gi-checkbox-group-checkboxes-container {
-  @apply gi-flex gi-flex-col gi-gap-2.5
+  @apply gi-flex gi-flex-col gi-gap-2.5;
 }
 .gi-checkbox-container {
-  @apply gi-flex gi-items-start
+  @apply gi-flex gi-items-start;
 }
 .gi-checkbox-input {
-  @apply gi-focus-state-outline gi-cursor-pointer gi-appearance-none gi-border-md gi-border-solid gi-border-black checked:before:gi-block checked:before:gi--rotate-45 checked:before:gi-relative checked:before:gi-border-l-lg checked:before:gi-border-b-lg checked:before:gi-border-black
+  @apply gi-focus-state-outline gi-cursor-pointer gi-appearance-none gi-border-md gi-border-solid gi-border-black checked:before:gi-block checked:before:gi--rotate-45 checked:before:gi-relative checked:before:gi-border-l-lg checked:before:gi-border-b-lg checked:before:gi-border-black;
 }
 .gi-checkbox-label {
-  @apply gi-cursor-pointer gi-text-md gi-pl-4
+  @apply gi-cursor-pointer gi-text-md gi-pl-4;
 }
 
 /* End of Checkbox */

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -43,7 +43,7 @@ input[type='text'] {
 
 /* General Input disable state */
 .gi-input-disabled-state {
-  @apply disabled:gi-bg-gray-200 disabled:gi-border-gray-400;
+  @apply disabled:gi-bg-gray-200 disabled:gi-border-gray-400 disabled:gi-text-gray-700 disabled:gi-cursor-not-allowed;
 }
 /* General Input disable state */
 
@@ -773,7 +773,7 @@ input[type='file' i] {
   @apply gi-flex gi-items-start;
 }
 .gi-checkbox-input {
-  @apply gi-focus-state-outline gi-cursor-pointer gi-appearance-none gi-border-md gi-border-solid gi-border-black checked:before:gi-block checked:before:gi--rotate-45 checked:before:gi-relative checked:before:gi-border-l-lg checked:before:gi-border-b-lg checked:before:gi-border-black;
+  @apply hover:gi-outline hover:gi-outline-[3px] hover:gi-outline-gray-200 hover:gi-outline-offset-0 disabled:hover:gi-outline-none gi-focus-state-outline gi-cursor-pointer gi-appearance-none gi-border-md gi-border-solid gi-border-black checked:before:gi-block  checked:before:gi--rotate-45 checked:before:gi-relative checked:before:gi-border-l-lg checked:before:gi-border-b-lg checked:before:gi-border-black gi-input-disabled-state disabled:before:gi-border-gray-700;
 }
 .gi-checkbox-label {
   @apply gi-cursor-pointer gi-text-md gi-pl-4;

--- a/packages/html/ds/src/button/button.stories.ts
+++ b/packages/html/ds/src/button/button.stories.ts
@@ -93,7 +93,7 @@ export const AllVariants: Story = {
       <button class="gi-btn gi-btn-flat gi-btn-regular focus-selector">Flat Focus</button>
       <button class="gi-btn gi-btn-flat gi-btn-regular gi-btn-flat-disabled">Flat Disabled</button>
     </div>
-    <div class="gi-flex gi-gap-4>
+    <div class="gi-flex gi-gap-4">
       <button class="gi-btn gi-btn-primary-dark gi-btn-regular">Primary Dark</button>
       <button class="gi-btn gi-btn-primary-dark gi-btn-regular hover-selector">Primary Dark Hover</button>
       <button class="gi-btn gi-btn-primary-dark gi-btn-regular focus-selector">Primary Dark Focus</button>

--- a/packages/html/ds/src/button/button.stories.ts
+++ b/packages/html/ds/src/button/button.stories.ts
@@ -74,24 +74,69 @@ export const Default: Story = {
 export const AllVariants: Story = {
   //@ts-expect-error Render function returns raw HTML string, not a React component
   render: () => `
-    <div class="gi-flex gi-flex-col gi-gap-4">
-      <div class="gi-flex gi-gap-4">
-        <button class="gi-btn gi-btn-primary gi-btn-regular">Primary</button>
-        <button class="gi-btn gi-btn-secondary gi-btn-regular">Secondary</button>
-        <button class="gi-btn gi-btn-flat gi-btn-regular">Flat</button>
-      </div>
-      <div class="gi-flex gi-gap-4">
-        <button class="gi-btn gi-btn-primary-dark gi-btn-regular">Primary Dark</button>
-        <button class="gi-btn gi-btn-secondary-dark gi-btn-regular">Secondary Dark</button>
-        <button class="gi-btn gi-btn-flat-dark gi-btn-regular">Flat Dark</button>
-      </div>
-      <div class="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit">
-        <button class="gi-btn gi-btn-primary-light gi-btn-regular">Primary Light</button>
-        <button class="gi-btn gi-btn-secondary-light gi-btn-regular">Secondary Light</button>
-        <button class="gi-btn gi-btn-flat-light gi-btn-regular">Flat Light</button>
-      </div>
+  <div class="gi-flex gi-flex-col gi-gap-4">
+    <div class="gi-flex gi-gap-4">
+      <button class="gi-btn gi-btn-primary gi-btn-regular">Primary</button>
+      <button class="gi-btn gi-btn-primary gi-btn-regular hover-selector">Primary Hover</button>
+      <button class="gi-btn gi-btn-primary gi-btn-regular focus-selector">Primary Focus</button>
+      <button class="gi-btn gi-btn-primary gi-btn-regular gi-btn-primary-disabled">Primary Disabled</button>
     </div>
-  `,
+    <div class="gi-flex gi-gap-4">
+      <button class="gi-btn gi-btn-secondary gi-btn-regular">Secondary</button>
+      <button class="gi-btn gi-btn-secondary gi-btn-regular hover-selector">Secondary Hover</button>
+      <button class="gi-btn gi-btn-secondary gi-btn-regular focus-selector">Secondary Focus</button>
+      <button class="gi-btn gi-btn-secondary gi-btn-regular gi-btn-secondary-disabled">Secondary Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4">
+      <button class="gi-btn gi-btn-flat gi-btn-regular">Flat</button>
+      <button class="gi-btn gi-btn-flat gi-btn-regular hover-selector">Flat Hover</button>
+      <button class="gi-btn gi-btn-flat gi-btn-regular focus-selector">Flat Focus</button>
+      <button class="gi-btn gi-btn-flat gi-btn-regular gi-btn-flat-disabled">Flat Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4>
+      <button class="gi-btn gi-btn-primary-dark gi-btn-regular">Primary Dark</button>
+      <button class="gi-btn gi-btn-primary-dark gi-btn-regular hover-selector">Primary Dark Hover</button>
+      <button class="gi-btn gi-btn-primary-dark gi-btn-regular focus-selector">Primary Dark Focus</button>
+      <button class="gi-btn gi-btn-primary-dark gi-btn-regular gi-btn-primary-disabled">Primary Dark Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4">
+      <button class="gi-btn gi-btn-secondary-dark gi-btn-regular">Secondary Dark</button>
+      <button class="gi-btn gi-btn-secondary-dark gi-btn-regular hover-selector">Secondary Dark Hover</button>
+      <button class="gi-btn gi-btn-secondary-dark gi-btn-regular focus-selector">Secondary Dark Focus</button>
+      <button class="gi-btn gi-btn-secondary-dark gi-btn-regular gi-btn-primary-disabled">Secondary Dark Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4">
+      <button class="gi-btn gi-btn-flat-dark gi-btn-regular">Flat Dark</button>
+      <button class="gi-btn gi-btn-flat-dark gi-btn-regular hover-selector">Flat Dark Hover</button>
+      <button class="gi-btn gi-btn-flat-dark gi-btn-regular focus-selector">Flat Dark Focus</button>
+      <button class="gi-btn gi-btn-flat-dark gi-btn-regular gi-btn-primary-disabled">Flat Dark Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit">
+      <button class="gi-btn gi-btn-primary-light gi-btn-regular">Primary Light</button>
+      <button class="gi-btn gi-btn-primary-light gi-btn-regular hover-selector">Primary Light Hover</button>
+      <button class="gi-btn gi-btn-primary-light gi-btn-regular focus-selector">Primary Light Focus</button>
+      <button class="gi-btn gi-btn-primary-light gi-btn-regular" disabled>Primary Light Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit">
+      <button class="gi-btn gi-btn-secondary-light gi-btn-regular">Secondary Light</button>
+      <button class="gi-btn gi-btn-secondary-light gi-btn-regular hover-selector">Secondary Light Hover</button>
+      <button class="gi-btn gi-btn-secondary-light gi-btn-regular focus-selector">Secondary Light Focus</button>
+      <button class="gi-btn gi-btn-secondary-light gi-btn-regular" disabled>Secondary Light Disabled</button>
+    </div>
+    <div class="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit">
+      <button class="gi-btn gi-btn-flat-light gi-btn-regular">Flat Light</button>
+      <button class="gi-btn gi-btn-flat-light gi-btn-regular hover-selector">Flat Light Hover</button>
+      <button class="gi-btn gi-btn-flat-light gi-btn-regular focus-selector">Flat Light Focus</button>
+      <button class="gi-btn gi-btn-flat-light gi-btn-regular" disabled>Flat Light Disabled</button>
+    </div>
+  </div>
+`,
+  parameters: {
+    pseudo: {
+      hover: '.hover-selector',
+      focus: '.focus-selector',
+    },
+  },
 };
 
 export const WithLeftIcon: Story = {

--- a/packages/html/ds/src/checkbox/checkbox.html
+++ b/packages/html/ds/src/checkbox/checkbox.html
@@ -6,6 +6,7 @@
   <div class="gi-checkbox-container {{ addClasses(props.className) | trim }}">
     <input
       {% if props.label %}name="{{ props.label }}"{% endif %}
+      {% if props.disabled %}disabled{% endif %}
       data-element="{{ props.dataElement }}"
       id="{{ props.checkboxId }}"
       value="{{ props.value }}"

--- a/packages/html/ds/src/checkbox/checkboxes-group.html
+++ b/packages/html/ds/src/checkbox/checkboxes-group.html
@@ -57,7 +57,8 @@
               "hint": checkbox.hint,
               "checkboxId": props.fieldId + "-" + loop.index0,
               "size": props.size,
-              "dataElement": "checkbox" + loop.index0
+              "dataElement": "checkbox" + loop.index0,
+              "disabled": checkbox.disabled
             })
           }}
         {% endfor %}

--- a/packages/html/ds/src/checkbox/checkboxes.schema.ts
+++ b/packages/html/ds/src/checkbox/checkboxes.schema.ts
@@ -32,6 +32,11 @@ export const checkboxesSchema = zod.object({
         })
         .optional(),
       className: zod.string({ description: 'aditional classes' }).optional(),
+      disabled: zod
+        .boolean({
+          description: 'Disable state for item',
+        })
+        .optional(),
     })
     .describe(
       'Array of the checkboxes which include the label,value and hint properties',

--- a/packages/html/ds/src/checkbox/checkboxes.stories.ts
+++ b/packages/html/ds/src/checkbox/checkboxes.stories.ts
@@ -118,6 +118,11 @@ export const Default: Story = {
         label: 'Department for Transport',
         value: 'department-for-transport',
       },
+      {
+        label: 'Others',
+        value: 'others',
+        disabled: true,
+      },
     ],
     title: {
       value: 'Organisation',
@@ -218,4 +223,79 @@ export const withNoneOption: Story = {
       value: 'no-travel',
     },
   },
+};
+
+export const AllStates: Story = {
+  //@ts-expect-error Render function returns raw HTML string, not a React component
+  render: () =>
+    `<div class="gi-flex gi-gap-4 gi-flex-col">
+      <div class="gi-checkbox-group-checkboxes-container">
+        <div class="gi-checkbox-container">
+          <input
+            name="Default"
+            data-element="checkbox0"
+            id="default-checkbox-0"
+            class="gi-w-8 gi-h-8 checked:before:gi-w-5 checked:before:gi-h-2.5 checked:before:gi-left-1 checked:before:gi-top-1.5 gi-checkbox-input"
+            type="checkbox"
+            value="default"
+          />
+          <label for="default-checkbox-0" class="gi-checkbox-label">Default</label>
+        </div>
+    </div>
+    <div class="gi-checkbox-group-container">
+      <fieldset>
+        <div class="gi-checkbox-group-checkboxes-container">
+          <div class="gi-checkbox-container">
+            <input
+              name="Hover"
+              data-element="checkbox0"
+              id="hover-checkbox-0"
+              class="gi-w-8 gi-h-8 checked:before:gi-w-5 checked:before:gi-h-2.5 checked:before:gi-left-1 checked:before:gi-top-1.5 gi-checkbox-input pseudo-hover"
+              type="checkbox"
+              value="hover"
+            />
+            <label for="hover-checkbox-0" class="gi-checkbox-label">Hover</label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  
+    <div class="gi-checkbox-group-container">
+      <fieldset>
+        <div class="gi-checkbox-group-checkboxes-container">
+          <div class="gi-checkbox-container">
+            <input
+              name="Focus"
+              data-element="checkbox0"
+              id="focus-checkbox-0"
+              class="gi-w-8 gi-h-8 checked:before:gi-w-5 checked:before:gi-h-2.5 checked:before:gi-left-1 checked:before:gi-top-1.5 gi-checkbox-input pseudo-focus"
+              type="checkbox"
+              value="focus"
+            />
+            <label for="focus-checkbox-0" class="gi-checkbox-label">Focus</label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  
+    <div class="gi-checkbox-group-container">
+      <fieldset>
+        <div class="gi-checkbox-group-checkboxes-container">
+          <div class="gi-checkbox-container">
+            <input
+              name="Disabled"
+              data-element="checkbox0"
+              id="disabled-checkbox-0"
+              class="gi-w-8 gi-h-8 checked:before:gi-w-5 checked:before:gi-h-2.5 checked:before:gi-left-1 checked:before:gi-top-1.5 gi-checkbox-input"
+              disabled
+              type="checkbox"
+              value="disabled"
+            />
+            <label for="disabled-checkbox-0" class="gi-checkbox-label">Disabled</label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+  `,
 };

--- a/packages/html/ds/src/text-input/text-input.html
+++ b/packages/html/ds/src/text-input/text-input.html
@@ -67,13 +67,14 @@
       {% endif %}
 
       <input
+        {% if props.disabled %}disabled{% endif %}
         id="{{ inputId }}"
         {% if props.placeholder %}placeholder="{{ props.placeholder }}"{% endif %}
         data-testid="textbox"
         {{ widthStyle | safe }}
         type="{{ props.type or 'text' }}"
         autocomplete="{{ props.autoComplete or 'on' }}"
-        class="{% if isError %}gi-border-red-600{% else %}gi-border-gray-950{% endif %} {{ widthClass }} gi-text-input"
+        class="{% if isError %}gi-border-red-600{% else %}gi-border-gray-950{% endif %} {{ widthClass }} gi-text-input "
       />
 
       {% if props.suffix %}

--- a/packages/html/ds/src/text-input/text-input.schema.ts
+++ b/packages/html/ds/src/text-input/text-input.schema.ts
@@ -67,6 +67,7 @@ export const textInputSchema = zod.object({
   placeholder: zod
     .string({ description: 'The placeholder for the input element' })
     .optional(),
+  disabled: zod.boolean({ description: 'Disabled state' }).optional(),
 });
 
 export type TextInputProps = zod.infer<typeof textInputSchema>;

--- a/packages/html/ds/src/text-input/text-input.stories.ts
+++ b/packages/html/ds/src/text-input/text-input.stories.ts
@@ -116,6 +116,14 @@ const meta = {
         defaultValue: { summary: '-' },
       },
     },
+    disabled: {
+      description: 'Disable input',
+      control: 'boolean',
+      table: {
+        category: 'Behavior',
+        type: { summary: 'Behavior' },
+      },
+    },
   },
 } satisfies Meta<typeof TextInput>;
 
@@ -238,5 +246,66 @@ export const DateInput: Story = {
     },
     id: 'text-input-id',
     type: InputTypeEnum.Date,
+  },
+};
+
+export const DisabledInput: Story = {
+  args: {
+    label: {
+      content: 'Label',
+      for: 'text-input-id',
+    },
+    id: 'text-input-id',
+    type: InputTypeEnum.Text,
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  //@ts-expect-error Render function returns raw HTML string, not a React component
+  render: () => `
+  <div class="gi-gap-4">
+  <div class="gi-text-input-container">
+    <label class="gi-text-md gi-label gi-mb-2" for="default-input">Default</label>
+    <div class="gi-text-input-container-inner">
+      <input
+        id="default-input"
+        type="text"
+        data-testid="textbox"
+        class="gi-border-gray-950 gi-w-full gi-text-input"
+      />
+    </div>
+  </div>
+
+  <div class="gi-text-input-container">
+    <label class="gi-text-md gi-label gi-mb-2" for="focus-input">Focus</label>
+    <div class="gi-text-input-container-inner">
+      <input
+        id="focus-input"
+        type="text"
+        data-testid="textbox"
+        class="gi-border-gray-950 gi-w-full gi-text-input pseudo-focus"
+      />
+    </div>
+  </div>
+
+  <div class="gi-text-input-container">
+    <label class="gi-text-md gi-label gi-mb-2" for="input-disabled">Disabled</label>
+    <div class="gi-text-input-container-inner">
+      <input
+        id="input-disabled"
+        type="text"
+        data-testid="textbox"
+        class="gi-border-gray-950 gi-w-full gi-text-input gi-text-input-disabled"
+        disabled
+      />
+    </div>
+  </div>
+</div>
+`,
+  parameters: {
+    pseudo: {
+      focus: '#focus-input',
+    },
   },
 };

--- a/packages/html/ds/src/textarea/textarea.html
+++ b/packages/html/ds/src/textarea/textarea.html
@@ -64,6 +64,7 @@
         cols="{{ props.cols or 100 }}"
         maxlength="{{ props.maxChars }}"
         autocomplete="{{ props.autoComplete or 'on' }}"
+        {% if props.disabled %}disabled{% endif %}
         class="{% if isError %}gi-textarea-error{% else %}gi-textarea{% endif %} {{ widthClass }} "
       ></textarea>
     </div>

--- a/packages/html/ds/src/textarea/textarea.schema.ts
+++ b/packages/html/ds/src/textarea/textarea.schema.ts
@@ -35,6 +35,7 @@ export const textAreaSchema = zod.object({
   error: errorTextSchema
     .describe('Set error boundaries for texarea')
     .optional(),
+  disabled: zod.boolean({ description: 'Disabled state' }).optional(),
 });
 
 export type TextareaProps = zod.infer<typeof textAreaSchema>;

--- a/packages/html/ds/src/textarea/textarea.stories.ts
+++ b/packages/html/ds/src/textarea/textarea.stories.ts
@@ -84,6 +84,14 @@ const meta = {
         defaultValue: { summary: 'textarea-id' },
       },
     },
+    disabled: {
+      description: 'Disable textarea',
+      control: 'boolean',
+      table: {
+        category: 'Behavior',
+        type: { summary: 'Behavior' },
+      },
+    },
   },
 } satisfies Meta<typeof TextArea>;
 
@@ -179,5 +187,77 @@ export const WithMaxChars: Story = {
     },
     maxChars: 100,
     id: 'textarea-id-5',
+  },
+};
+
+export const DisabledTextarea: Story = {
+  args: {
+    label: {
+      content: 'Textarea Label',
+      for: 'textarea-id-5',
+    },
+    hint: {
+      content: 'Hint text for textarea',
+    },
+    id: 'textarea-id-5',
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  //@ts-expect-error Render function returns raw HTML string, not a React component
+  render: () => `
+  <div class="gi-gap-4">
+  <div class="gi-textarea-layout-container undefined">
+    <label class="gi-text-md gi-label gi-mb-2" for="default-textarea" id=":r7:-label">Default</label>
+    <div class="gi-textarea-container">
+      <textarea
+        id="default-textarea"
+        rows="4"
+        cols="100"
+        autocomplete="on"
+        class="gi-textarea"
+        aria-labelledby=":r7:-label"
+        aria-describedby=""
+      ></textarea>
+    </div>
+  </div>
+
+  <div class="gi-textarea-layout-container undefined">
+    <label class="gi-text-md gi-label gi-mb-2" for="focus-textarea" id=":r8:-label">Focus</label>
+    <div class="gi-textarea-container">
+      <textarea
+        id="focus-textarea"
+        rows="4"
+        cols="100"
+        autocomplete="on"
+        class="gi-textarea pseudo-focus"
+        aria-labelledby=":r8:-label"
+        aria-describedby=""
+      ></textarea>
+    </div>
+  </div>
+
+  <div class="gi-textarea-layout-container undefined">
+    <label class="gi-text-md gi-label gi-mb-2" for="textarea-disabled" id=":r9:-label">Disabled</label>
+    <div class="gi-textarea-container">
+      <textarea
+        id="textarea-disabled"
+        rows="4"
+        cols="100"
+        autocomplete="on"
+        class="gi-textarea gi-textarea-disabled"
+        aria-labelledby=":r9:-label"
+        aria-describedby=""
+        disabled
+      ></textarea>
+    </div>
+  </div>
+</div>
+`,
+  parameters: {
+    pseudo: {
+      focus: '#focus-textarea',
+    },
   },
 };

--- a/packages/html/storybook/.storybook/main.ts
+++ b/packages/html/storybook/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-onboarding',
     '@storybook/addon-viewport',
+    'storybook-addon-pseudo-states',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/packages/react/ds/src/button/button.stories.tsx
+++ b/packages/react/ds/src/button/button.stories.tsx
@@ -73,37 +73,205 @@ export const AllVariants: Story = {
         <Button variant="primary" size="medium">
           Primary
         </Button>
+        <Button variant="primary" size="medium" className="hover-selector">
+          Primary Hover
+        </Button>
+        <Button variant="primary" size="medium" className="focus-selector">
+          Primary Focus
+        </Button>
+        <Button variant="primary" size="medium" disabled>
+          Primary Disabled
+        </Button>
+      </div>
+      <div className="gi-flex gi-gap-4">
         <Button variant="secondary" size="medium">
           Secondary
         </Button>
+        <Button variant="secondary" size="medium" className="hover-selector">
+          Secondary Hover
+        </Button>
+        <Button variant="secondary" size="medium" className="focus-selector">
+          Secondary Focus
+        </Button>
+        <Button variant="secondary" size="medium" disabled>
+          Secondary Disabled
+        </Button>
+      </div>
+      <div className="gi-flex gi-gap-4">
         <Button variant="flat" size="medium">
           Flat
+        </Button>
+        <Button variant="flat" size="medium" className="hover-selector">
+          Flat Hover
+        </Button>
+        <Button variant="flat" size="medium" className="focus-selector">
+          Flat Focus
+        </Button>
+        <Button variant="flat" size="medium" disabled>
+          Flat Disabled
         </Button>
       </div>
       <div className="gi-flex gi-gap-4">
         <Button variant="primary" size="medium" appearance="dark">
           Primary Dark
         </Button>
+        <Button
+          variant="primary"
+          size="medium"
+          appearance="dark"
+          className="hover-selector"
+        >
+          Primary Dark Hover
+        </Button>
+        <Button
+          variant="primary"
+          size="medium"
+          appearance="dark"
+          className="focus-selector"
+        >
+          Primary Dark Focus
+        </Button>
+        <Button variant="primary" size="medium" appearance="dark" disabled>
+          Primary Dark Disabled
+        </Button>
+      </div>
+      <div className="gi-flex gi-gap-4">
         <Button variant="secondary" size="medium" appearance="dark">
           Secondary Dark
         </Button>
+        <Button
+          variant="secondary"
+          size="medium"
+          appearance="dark"
+          className="hover-selector"
+        >
+          Secondary Dark Hover
+        </Button>
+        <Button
+          variant="secondary"
+          size="medium"
+          appearance="dark"
+          className="focus-selector"
+        >
+          Secondary Dark Focus
+        </Button>
+        <Button variant="secondary" size="medium" appearance="dark" disabled>
+          Secondary Dark Disabled
+        </Button>
+      </div>
+      <div className="gi-flex gi-gap-4">
         <Button variant="flat" size="medium" appearance="dark">
           Flat Dark
         </Button>
+        <Button
+          variant="flat"
+          size="medium"
+          appearance="dark"
+          className="hover-selector"
+        >
+          Flat Dark Hover
+        </Button>
+        <Button
+          variant="flat"
+          size="medium"
+          appearance="dark"
+          className="focus-selector"
+        >
+          Flat Dark Focus
+        </Button>
+        <Button variant="flat" size="medium" appearance="dark" disabled>
+          Flat Dark Disabled
+        </Button>
       </div>
-      <div className="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit">
+      <div
+        className="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit"
+        data-testid="light-appearance"
+      >
         <Button variant="primary" size="medium" appearance="light">
           Primary Light
         </Button>
+        <Button
+          variant="primary"
+          size="medium"
+          appearance="light"
+          className="hover-selector"
+        >
+          Primary Light Hover
+        </Button>
+        <Button
+          variant="primary"
+          size="medium"
+          appearance="light"
+          className="focus-selector"
+        >
+          Primary Light Focus
+        </Button>
+        <Button variant="primary" size="medium" appearance="light" disabled>
+          Primary Light Disabled
+        </Button>
+      </div>
+      <div
+        className="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit"
+        data-testid="light-appearance"
+      >
         <Button variant="secondary" size="medium" appearance="light">
           Secondary Light
         </Button>
+        <Button
+          variant="secondary"
+          size="medium"
+          appearance="light"
+          className="hover-selector"
+        >
+          Secondary Light Hover
+        </Button>
+        <Button
+          variant="secondary"
+          size="medium"
+          appearance="light"
+          className="focus-selector"
+        >
+          Secondary Light Focus
+        </Button>
+        <Button variant="secondary" size="medium" appearance="light" disabled>
+          Secondary Light Disabled
+        </Button>
+      </div>
+      <div
+        className="gi-flex gi-gap-4 gi-bg-black gi-p-4 gi-w-fit"
+        data-testid="light-appearance"
+      >
         <Button variant="flat" size="medium" appearance="light">
           Flat Light
+        </Button>
+        <Button
+          variant="flat"
+          size="medium"
+          appearance="light"
+          className="hover-selector"
+        >
+          Flat Light Hover
+        </Button>
+        <Button
+          variant="flat"
+          size="medium"
+          appearance="light"
+          className="focus-selector"
+        >
+          Flat Light Focus
+        </Button>
+        <Button variant="flat" size="medium" appearance="light" disabled>
+          Flat Light Disabled
         </Button>
       </div>
     </div>
   ),
+  parameters: {
+    pseudo: {
+      hover: '.hover-selector',
+      focus: '.focus-selector',
+    },
+  },
 };
 
 export const WithIconLeft: Story = {
@@ -116,7 +284,6 @@ export const WithIconLeft: Story = {
     ),
   },
 };
-
 export const WithIconRight: Story = {
   args: {
     children: (

--- a/packages/react/ds/src/button/button.tsx
+++ b/packages/react/ds/src/button/button.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { cn } from '../cn.js';
 import {
   isButtonDisabled,
   getSizeClass,
@@ -16,6 +17,7 @@ export const Button = ({
   type,
   form,
   value,
+  className,
 }: ButtonProps) => {
   return (
     <button
@@ -24,7 +26,13 @@ export const Button = ({
       value={value}
       data-testid={`govieButton-${appearance}-${variant}-${size}-${disabled ? 'disabled' : ''}`}
       onClick={onClick}
-      className={`gi-btn ${getVariantAppearanceClass({ disabled, variant, appearance })} ${getSizeClass(size)} ${isButtonDisabled({ disabled, variant, appearance })}`}
+      className={cn(
+        'gi-btn',
+        getVariantAppearanceClass({ disabled, variant, appearance }),
+        getSizeClass(size),
+        isButtonDisabled({ disabled, variant, appearance }),
+        className,
+      )}
     >
       {children}
     </button>

--- a/packages/react/ds/src/button/types.ts
+++ b/packages/react/ds/src/button/types.ts
@@ -16,4 +16,5 @@ export type ButtonProps = {
   type?: ButtonType;
   form?: string;
   value?: string;
+  className?: string;
 };

--- a/packages/react/ds/src/checkbox/checkbox.stories.tsx
+++ b/packages/react/ds/src/checkbox/checkbox.stories.tsx
@@ -107,6 +107,11 @@ export const Default: Story = {
         label: 'Department for Transport',
         value: 'department-for-transport',
       },
+      {
+        label: 'Others',
+        value: 'others',
+        disabled: true,
+      },
     ],
     title: {
       value: 'Organisation',
@@ -205,6 +210,65 @@ export const withNoneOption: Story = {
     noneOption: {
       label: 'No, I will not be travelling to any of these countries',
       value: 'no-travel',
+    },
+  },
+};
+
+export const AllStates: Story = {
+  args: {
+    fieldId: 'govie-field-ID',
+    items: [
+      {
+        label: '',
+        value: '',
+      },
+    ],
+  },
+  render: () => (
+    <div className="gi-flex gi-gap-4 gi-flex-col">
+      <CheckboxesGroup
+        items={[
+          {
+            label: 'Default',
+            value: 'default',
+          },
+        ]}
+        fieldId="default-checkbox"
+      />
+      <CheckboxesGroup
+        items={[
+          {
+            label: 'Hover',
+            value: 'hover',
+          },
+        ]}
+        fieldId="hover-checkbox"
+      />
+      <CheckboxesGroup
+        items={[
+          {
+            label: 'Focus',
+            value: 'focus',
+          },
+        ]}
+        fieldId="focus-checkbox"
+      />
+      <CheckboxesGroup
+        items={[
+          {
+            label: 'Disabled',
+            value: 'disabled',
+            disabled: true,
+          },
+        ]}
+        fieldId="disabled-checkbox"
+      />
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      hover: '#hover-checkbox-0',
+      focus: '#focus-checkbox-0',
     },
   },
 };

--- a/packages/react/ds/src/checkbox/checkbox.tsx
+++ b/packages/react/ds/src/checkbox/checkbox.tsx
@@ -17,6 +17,7 @@ type CheckboxType = {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   className?: string;
   checked?: boolean;
+  disabled?: boolean;
 };
 
 const Checkbox = ({
@@ -29,6 +30,7 @@ const Checkbox = ({
   hint,
   className,
   checked,
+  disabled,
 }: CheckboxType) => {
   return (
     <div className={`gi-checkbox-container ${className && className}`}>
@@ -40,6 +42,7 @@ const Checkbox = ({
         value={value}
         className={`${getSizeClass(size)} ${getTickSize(size)} gi-checkbox-input`}
         checked={checked}
+        disabled={disabled}
         type="checkbox"
       />
       <label htmlFor={checkboxId} className="gi-checkbox-label">

--- a/packages/react/ds/src/checkbox/checkboxes-group.tsx
+++ b/packages/react/ds/src/checkbox/checkboxes-group.tsx
@@ -14,6 +14,7 @@ export type CheckboxesGroupType = {
     value: string;
     label?: string;
     hint?: string;
+    disabled?: boolean;
   }[];
   title?: {
     value: string;
@@ -102,6 +103,7 @@ export const CheckboxesGroup = ({
               hint={checkbox.hint}
               value={checkbox.value}
               label={checkbox.label}
+              disabled={checkbox.disabled}
               checked={selectedValues.includes(checkbox.value)}
               onChange={() => handleCheckboxChange(checkbox.value)}
             />

--- a/packages/react/ds/src/text-input/text-input.stories.tsx
+++ b/packages/react/ds/src/text-input/text-input.stories.tsx
@@ -248,6 +248,7 @@ export const DisabledInput: Story = {
     },
     id: 'text-input-id',
     disabled: true,
+    value: 'This field is disabled',
   },
 };
 
@@ -266,6 +267,7 @@ export const AllStates: Story = {
       />
       <TextInput
         label={{ text: 'Disabled', htmlFor: 'input-disabled' }}
+        value="This field is disabled"
         type="text"
         id="input-disabled"
         disabled

--- a/packages/react/ds/src/text-input/text-input.stories.tsx
+++ b/packages/react/ds/src/text-input/text-input.stories.tsx
@@ -111,6 +111,14 @@ const meta = {
         type: { summary: 'string' },
       },
     },
+    disabled: {
+      description: 'Disable input',
+      control: 'boolean',
+      table: {
+        category: 'Behavior',
+        type: { summary: 'Behavior' },
+      },
+    },
   },
 } satisfies Meta<typeof TextInput>;
 
@@ -229,5 +237,44 @@ export const DateInput: Story = {
       htmlFor: 'text-input-id',
     },
     type: 'date',
+  },
+};
+
+export const DisabledInput: Story = {
+  args: {
+    label: {
+      text: 'Disabled',
+      htmlFor: 'text-input-id',
+    },
+    id: 'text-input-id',
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="gi-gap-4">
+      <TextInput
+        label={{ text: 'Default', htmlFor: 'default-input' }}
+        type="text"
+        id="default-input"
+      />
+      <TextInput
+        label={{ text: 'Focus', htmlFor: 'focus-input' }}
+        type="text"
+        id="focus-input"
+      />
+      <TextInput
+        label={{ text: 'Disabled', htmlFor: 'input-disabled' }}
+        type="text"
+        id="input-disabled"
+        disabled
+      />
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      focus: '#focus-input',
+    },
   },
 };

--- a/packages/react/ds/src/textarea/textarea.stories.tsx
+++ b/packages/react/ds/src/textarea/textarea.stories.tsx
@@ -187,6 +187,7 @@ export const DisabledState: Story = {
       text: 'Hint: This is a helpful hint.',
     },
     disabled: true,
+    value: 'This field is disabled',
   },
 };
 
@@ -204,6 +205,7 @@ export const AllStates: Story = {
       <TextArea
         label={{ text: 'Disabled', htmlFor: 'textarea-disabled' }}
         id="textarea-disabled"
+        value="This field is disabled"
         disabled
       />
     </div>

--- a/packages/react/ds/src/textarea/textarea.stories.tsx
+++ b/packages/react/ds/src/textarea/textarea.stories.tsx
@@ -74,6 +74,14 @@ const meta = {
         type: { summary: 'React.Ref<HTMLTextAreaElement>' },
       },
     },
+    disabled: {
+      description: 'Disable textarea',
+      control: 'boolean',
+      table: {
+        category: 'Behavior',
+        type: { summary: 'Behavior' },
+      },
+    },
   },
 } satisfies Meta<typeof TextArea>;
 
@@ -165,5 +173,44 @@ export const WithMaxChars: Story = {
       text: 'Hint: This is a helpful hint.',
     },
     maxChars: 100,
+  },
+};
+
+export const DisabledState: Story = {
+  args: {
+    id: 'textarea-id-5',
+    label: {
+      text: 'Label',
+      htmlFor: 'textarea-id-5',
+    },
+    hint: {
+      text: 'Hint: This is a helpful hint.',
+    },
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="gi-gap-4">
+      <TextArea
+        label={{ text: 'Default', htmlFor: 'default-textarea' }}
+        id="default-textarea"
+      />
+      <TextArea
+        label={{ text: 'Focus', htmlFor: 'focus-textarea' }}
+        id="focus-textarea"
+      />
+      <TextArea
+        label={{ text: 'Disabled', htmlFor: 'textarea-disabled' }}
+        id="textarea-disabled"
+        disabled
+      />
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      focus: '#focus-textarea',
+    },
   },
 };

--- a/packages/react/storybook/.storybook/main.ts
+++ b/packages/react/storybook/.storybook/main.ts
@@ -11,6 +11,7 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-onboarding',
     '@storybook/addon-viewport',
+    'storybook-addon-pseudo-states',
   ],
   build: {
     test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       storybook:
         specifier: 8.3.6
         version: 8.3.6
+      storybook-addon-pseudo-states:
+        specifier: ^4.0.2
+        version: 4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6)
       tailwindcss:
         specifier: 3.4.14
         version: 3.4.14
@@ -8525,6 +8528,11 @@ packages:
   stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
+
+  storybook-addon-pseudo-states@4.0.2:
+    resolution: {integrity: sha512-dTHkeq4VzqIrJfR8k2BHkX190cQ+aYBZUktWNZpDw3N5tJ8IwaRLzf6ZjHDHY6xwDshaNiTO5UkziRE0Ytukkw==}
+    peerDependencies:
+      storybook: ^8.2.0
 
   storybook@8.3.6:
     resolution: {integrity: sha512-9GVbtej6ZzPRUM7KRQ7848506FfHrUiJGqPuIQdoSJd09EmuEoLjmLAgEOmrHBQKgGYMaM7Vh9GsTLim6vwZTQ==}
@@ -19077,6 +19085,14 @@ snapshots:
   stop-iteration-iterator@1.0.0:
     dependencies:
       internal-slot: 1.0.7
+
+  storybook-addon-pseudo-states@4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.6):
+    dependencies:
+      '@storybook/icons': 1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.3.6
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   storybook@8.3.6:
     dependencies:


### PR DESCRIPTION
### Adding component pseudo states on storybook for testing
- Added pseudo-states plugin to have control of focus and hover in storybook 
- Added disable style for input, text area and checkbox item
- Added hover state for checkbox

![Screenshot 2024-11-06 at 10 44 51](https://github.com/user-attachments/assets/9adfc3e9-5b5f-4be7-8cb7-e3b2cbb785d6)
![Screenshot 2024-11-06 at 12 15 18](https://github.com/user-attachments/assets/ce74b0ed-277e-43e1-a350-e4bf82e81941)
![Screenshot 2024-11-06 at 12 15 39](https://github.com/user-attachments/assets/e9449691-3961-4bef-8669-b1c311904a16)
![Screenshot 2024-11-06 at 13 26 19](https://github.com/user-attachments/assets/2cb0c517-a421-4c12-b3ae-18ff98694a8d)

