### PR TITLE
fix: radio feedback fixes

### DIFF
--- a/apps/docs/content/3-components/2-library/32-radio-button.mdx
+++ b/apps/docs/content/3-components/2-library/32-radio-button.mdx
@@ -98,7 +98,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
   <TabPanel value="tab12">
   ```html
   {{ govieRadiosGroup({
-    "fieldId": "uniqueId",
+    "groupId": "uniqueId",
     "title": {
       "value": "Where do you live?",
       "asHeading": {
@@ -149,7 +149,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
       value: 'ireland',
     },
   ]}
-  fieldId="uniqueId"
+  groupId="uniqueId"
 />;
 
   ```
@@ -246,7 +246,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
   <TabPanel value="tab22">
   ```html
   {{ govieRadiosGroup({
-    "fieldId": "uniqueId",
+    "groupId": "uniqueId",
     "inline": true,
     "title": {
       "value": "Where do you live?",
@@ -299,7 +299,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
       value: 'ireland',
     },
   ]}
-  fieldId="uniqueId"
+  groupId="uniqueId"
 />;
 
   ```
@@ -420,7 +420,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
   <TabPanel value="tab32">
   ```html
   {{ govieRadiosGroup({
-    "fieldId": "uniqueId",
+    "groupId": "uniqueId",
     "title": {
       "value": "Have you changed your name?",
       "hint": "This includes changing your last name or spelling your name differently."
@@ -470,7 +470,7 @@ import { standardProps, inlineProps, hintsProps } from "@/components/form/radio"
       hint: "No, I didn't change my name",
     },
   ]}
-  fieldId="uniqueId"
+  groupId="uniqueId"
 />;
 
   ```

--- a/apps/docs/dictionary.txt
+++ b/apps/docs/dictionary.txt
@@ -105,3 +105,4 @@ IconButton
 FileUpload
 HeadingResponsiveSizes
 sampleText
+groupId

--- a/apps/docs/src/components/form/radio.tsx
+++ b/apps/docs/src/components/form/radio.tsx
@@ -1,5 +1,5 @@
 export const standardProps = {
-  fieldId: 'uniqueId-1',
+  groupId: 'uniqueId-1',
   title: {
     value: 'Where do you live?',
     asHeading: {
@@ -25,12 +25,12 @@ export const standardProps = {
 
 export const inlineProps = {
   ...standardProps,
-  fieldId: 'uniqueId-2',
+  groupId: 'uniqueId-2',
   inline: true,
 };
 
 export const hintsProps = {
-  fieldId: 'uniqueId-3',
+  groupId: 'uniqueId-3',
   title: {
     value: 'Have you changed your name?',
     hint: 'This includes changing your last name or spelling your name differently.',

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -103,7 +103,7 @@ export default function Home() {
                 value: "ireland",
               },
             ]}
-            fieldId="uniqueId"
+            groupId="uniqueId"
           />
           <TextArea
             hint={{

--- a/examples/vite/src/application.tsx
+++ b/examples/vite/src/application.tsx
@@ -27,6 +27,7 @@ import {
   List,
   TypeEnum,
   Combobox,
+  Radio
 } from "@govie-ds/react";
 import { CookieBannerProps, ComboBoxProps } from "./props";
 
@@ -204,10 +205,15 @@ export function App() {
               value: "ireland",
             },
           ]}
-          fieldId="uniqueId"
+          groupId="uniqueId1"
+        />
+        <Heading size="sm">Single Radio</Heading>
+        <Radio
+          value='single-radio'
+          label="Single Radio"
         />
         <Modal triggerButton={<Button>Open Modal</Button>}>
-          <Heading as='h2'>Title</Heading>
+          <Heading as="h2">Title</Heading>
           <Paragraph>
             Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt
             esse magnam quis sit soluta cupiditate at deserunt exercitationem

--- a/examples/wagtail/core/jinja/home_page.jinja
+++ b/examples/wagtail/core/jinja/home_page.jinja
@@ -13,6 +13,7 @@
 {% from 'icon/icon.html' import govieIcon %}
 {% from 'tag/tag.html' import govieTag %}
 {% from 'radio/radios-group.html' import govieRadiosGroup %}
+{% from 'radio/radio.html' import govieRadio %}
 {% from 'modal/modal.html' import govieModal %}
 {% from 'icon-button/icon-button.html' import govieIconButton %}
 {% from 'cookie-banner/cookie-banner.html' import govieCookieBanner %}
@@ -178,9 +179,16 @@
     "content": 'Primary Button',
   }) }}
 
-  <h2>Radio</h2>
+  <h2>Radio Group Component</h2>
 
   {{ govieRadiosGroup(radioProps) }}
+
+  <h2>Radio</h2>
+
+  {{ govieRadio({
+    "value": "Radio",
+    "label": 'This is a single Radio Component'
+  }) }}
 
   <h2>Modal</h2>
 

--- a/examples/wagtail/core/jinja/vars.jinja
+++ b/examples/wagtail/core/jinja/vars.jinja
@@ -147,7 +147,7 @@
 %}
 
 {% set radioProps = {
-  "fieldId": "uniqueId",
+  "groupId": "uniqueId",
   "title": {
     "value": "Where do you live?",
     "asHeading": {

--- a/packages/html/ds/src/radio/radio-group.stories.ts
+++ b/packages/html/ds/src/radio/radio-group.stories.ts
@@ -1,0 +1,287 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Size, Tag } from '../heading/heading.schema';
+import { renderComponent } from '../storybook/storybook';
+import { InputTypeEnum } from '../text-input/text-input.schema';
+import type { RadiosProps } from './radio.schema';
+import html from './radios-group.html?raw';
+
+// Name of the folder the macro resides
+const path = import.meta.url.split('/radio')[0];
+
+const macro = { name: 'govieRadiosGroup', html, path };
+
+const Radios = renderComponent<RadiosProps>(macro);
+
+const standardProps = {
+  groupId: 'uniqueId',
+  title: {
+    value: 'Where do you live?',
+    asHeading: {
+      size: Size.Medium,
+      as: Tag.H2,
+    },
+  },
+  items: [
+    {
+      label: 'England',
+      value: 'england',
+    },
+    {
+      label: 'Scotland',
+      value: 'scotland',
+    },
+    {
+      label: 'Ireland',
+      value: 'ireland',
+    },
+  ],
+};
+
+const meta = {
+  component: Radios,
+  title: 'form/Radio/RadioGroup',
+  parameters: {
+    macro,
+    docs: {
+      description: {
+        component:
+          'Radio component when users can only select one option from a list.',
+      },
+    },
+  },
+} satisfies Meta<typeof Radios>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  argTypes: {
+    groupId: {
+      control: 'text',
+      type: { name: 'string', required: true },
+      description: 'The unique value for the radios group',
+    },
+    items: {
+      control: 'object',
+      type: {
+        name: 'object',
+        required: true,
+        value: {
+          label: {
+            name: 'string',
+          },
+          value: {
+            name: 'string',
+            required: true,
+          },
+          hint: {
+            name: 'string',
+          },
+          conditionalInput: {
+            name: 'other',
+            value:
+              'Conditional input associated with the radio (see text input component)',
+          },
+        },
+      },
+      description:
+        'A list of the label, values, hint and conditional for the radios',
+    },
+    inline: {
+      control: 'boolean',
+      description: 'Specify if the radios should be inline',
+    },
+    errorMessage: {
+      control: 'text',
+      type: { name: 'string' },
+      description: 'The text of the error message',
+    },
+    title: {
+      control: 'object',
+      type: {
+        name: 'object',
+        value: {
+          value: {
+            name: 'string',
+          },
+          asHeading: {
+            name: 'boolean',
+          },
+          hint: {
+            name: 'string',
+          },
+        },
+      },
+      description: 'The label, hint and option the make the title a heading',
+    },
+    size: {
+      control: 'radio',
+      options: ['lg', 'md', 'sm'],
+      description: 'The sizes of the checkboxes',
+    },
+  },
+  args: {
+    ...standardProps,
+    groupId: 'UniqueId1',
+  },
+};
+
+export const inline: Story = {
+  args: {
+    ...standardProps,
+    groupId: 'UniqueId2',
+    inline: true,
+  },
+};
+
+export const withTitleHint: Story = {
+  args: {
+    ...standardProps,
+    title: {
+      value: 'Where do you live?',
+      hint: 'Specify the location where you live',
+      asHeading: {
+        size: Size.Medium,
+        as: Tag.H2,
+      },
+    },
+    groupId: 'UniqueId3',
+  },
+};
+
+export const withOptionHints: Story = {
+  args: {
+    title: {
+      value: 'Have you changed your name?',
+      hint: 'This includes changing your last name or spelling your name differently.',
+      asHeading: {
+        size: Size.Medium,
+        as: Tag.H2,
+      },
+    },
+    items: [
+      {
+        label: 'Yes',
+        value: 'no',
+        hint: 'Yes, I have changed my name',
+      },
+      {
+        label: 'No',
+        value: 'no',
+        hint: "No, I didn't change my name",
+      },
+    ],
+    groupId: 'UniqueId4',
+  },
+};
+
+export const withDividerOption: Story = {
+  args: {
+    ...standardProps,
+    dividerOption: {
+      label: 'None of the above',
+      value: 'none of the above',
+    },
+    groupId: 'UniqueId5',
+  },
+};
+
+export const withError: Story = {
+  args: {
+    ...standardProps,
+    errorMessage: 'Please select an option',
+    groupId: 'UniqueId6',
+  },
+};
+
+export const withConditionalInput: Story = {
+  args: {
+    title: {
+      value: 'How would you prefer to be contacted?',
+      asHeading: {
+        size: Size.Medium,
+        as: Tag.H2,
+      },
+    },
+    items: [
+      {
+        label: 'Email',
+        value: 'email',
+        conditionalInput: {
+          id: 'input-id-email',
+          label: {
+            content: 'Email address',
+            for: 'input-id-email',
+          },
+          type: InputTypeEnum.Email,
+        },
+      },
+      {
+        label: 'Phone',
+        value: 'phone',
+        conditionalInput: {
+          id: 'input-id-phone',
+          label: {
+            content: 'Phone number',
+            for: 'input-id-phone',
+          },
+          type: InputTypeEnum.Tel,
+        },
+      },
+    ],
+    groupId: 'UniqueId7',
+  },
+};
+
+export const withNoTitle: Story = {
+  args: {
+    groupId: 'uniqueId8',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+      {
+        label: 'Scotland',
+        value: 'scotland',
+      },
+      {
+        label: 'Ireland',
+        value: 'ireland',
+      },
+    ],
+  },
+};
+
+export const singleRadio: Story = {
+  args: {
+    groupId: 'uniqueId9',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+    ],
+  },
+};
+
+export const withDefaultChecked: Story = {
+  args: {
+    groupId: 'uniqueId10',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+      {
+        label: 'Scotland',
+        value: 'scotland',
+      },
+      {
+        label: 'Ireland',
+        value: 'ireland',
+        checked: true,
+      },
+    ],
+  },
+};

--- a/packages/html/ds/src/radio/radio-group.stories.ts
+++ b/packages/html/ds/src/radio/radio-group.stories.ts
@@ -280,8 +280,8 @@ export const withDefaultChecked: Story = {
       {
         label: 'Ireland',
         value: 'ireland',
-        checked: true,
       },
     ],
+    defaultValue: 'ireland',
   },
 };

--- a/packages/html/ds/src/radio/radio.html
+++ b/packages/html/ds/src/radio/radio.html
@@ -18,6 +18,7 @@
         value="{{ props.value }}"
         class="{{ getRadioSize(props.size) | trim }} gi-radio-base"
         type="radio"
+        aria-label="{{ radioId }}"
       />
       {% if props.label %}
         <label for="{{ radioId }}" class="gi-radio-label">

--- a/packages/html/ds/src/radio/radio.html
+++ b/packages/html/ds/src/radio/radio.html
@@ -4,22 +4,26 @@
 
 {% macro govieRadio(props) %}
   {% set hasConditionalInput = true if props.conditionalInput %}
+  {% set radioId = props.radioId or props.id or props.value %}
 
   <div class="gi-radio-container">
     <div class="gi-radio-input-container">
       <input
-        name="{{ props.name }}"
-        data-has-conditional-input="{{ hasConditionalInput }}"
+        {% if props.checked %}checked="{{ props.checked }}"{% endif %}
+        {% if props.name %}name="{{ props.name }}"{% endif %}
+        {% if props.conditionalInput %}data-has-conditional-input="{{ hasConditionalInput }}"{% endif %}
         data-primary="true"
-        data-element="{{ props.dataElement }}"
-        id="{{ props.radioId }}"
+        {% if props.dataElement %}data-element="{{ props.dataElement }}"{% endif %}
+        id="{{ radioId }}"
         value="{{ props.value }}"
         class="{{ getRadioSize(props.size) | trim }} gi-radio-base"
         type="radio"
       />
-      <label for="{{ props.radioId }}" class="gi-radio-label">
-        {{ props.label }}
-      </label>
+      {% if props.label %}
+        <label for="{{ radioId }}" class="gi-radio-label">
+          {{ props.label }}
+        </label>
+      {% endif %}
     </div>
     {% if props.hint or props.conditionalInput %}
       <div class="gi-radio-conditional-divider-container">

--- a/packages/html/ds/src/radio/radio.html
+++ b/packages/html/ds/src/radio/radio.html
@@ -9,7 +9,7 @@
   <div class="gi-radio-container">
     <div class="gi-radio-input-container">
       <input
-        {% if props.checked %}checked="{{ props.checked }}"{% endif %}
+        {% if props.checked %}readonly checked{% endif %}
         {% if props.name %}name="{{ props.name }}"{% endif %}
         {% if props.conditionalInput %}data-has-conditional-input="{{ hasConditionalInput }}"{% endif %}
         data-primary="true"

--- a/packages/html/ds/src/radio/radio.schema.ts
+++ b/packages/html/ds/src/radio/radio.schema.ts
@@ -56,6 +56,11 @@ export const radiosSchema = zod.object({
       description: 'specify if the radios are inline',
     })
     .optional(),
+  defaultValue: zod
+    .string({
+      description: 'Specify the value of the radio that should be checked',
+    })
+    .optional(),
   items: zod
     .object({
       label: zod
@@ -77,9 +82,6 @@ export const radiosSchema = zod.object({
         .optional(),
       conditionalInput: textInputSchema
         .describe('Add a conditional input if neccessary')
-        .optional(),
-      checked: zod
-        .boolean({ description: 'if true the radio is checked' })
         .optional(),
     })
     .describe(

--- a/packages/html/ds/src/radio/radio.schema.ts
+++ b/packages/html/ds/src/radio/radio.schema.ts
@@ -8,8 +8,46 @@ export enum RadioSizeEnum {
   Small = 'sm',
 }
 
+export const radioSchema = zod.object({
+  value: zod.string({
+    description:
+      'The value associated with the input (this is also the value that is sent on submit)',
+    required_error: 'The value associated with the input is required',
+  }),
+  name: zod
+    .string({
+      description: 'Name attribute of the input element',
+    })
+    .optional(),
+  label: zod
+    .string({
+      description:
+        'The value of the radio that will be displayed on the screen',
+    })
+    .optional(),
+  hint: zod
+    .string({
+      description:
+        'If there is additional text required in order to give the user more context',
+    })
+    .optional(),
+  id: zod
+    .string({
+      description: 'The id of the Radio',
+    })
+    .optional(),
+  size: zod
+    .nativeEnum(RadioSizeEnum, {
+      description: 'Specifies the size of the radio',
+    })
+    .optional(),
+  checked: zod
+    .boolean({ description: 'if true the component is checked' })
+    .optional(),
+});
+
 export const radiosSchema = zod.object({
-  fieldId: zod.string({
+  groupId: zod.string({
     description: 'An unique ID given to the group of radios',
     required_error: 'The unique ID is required',
   }),
@@ -40,6 +78,9 @@ export const radiosSchema = zod.object({
       conditionalInput: textInputSchema
         .describe('Add a conditional input if neccessary')
         .optional(),
+      checked: zod
+        .boolean({ description: 'if true the radio is checked' })
+        .optional(),
     })
     .describe(
       'Array of the radios which include the label,value and hint properties',
@@ -62,6 +103,9 @@ export const radiosSchema = zod.object({
         .string({
           description: 'The value of additional text of the divider radio',
         })
+        .optional(),
+      checked: zod
+        .boolean({ description: 'if true the radio is checked' })
         .optional(),
     })
     .describe('if a radio is required with a separation from the other options')
@@ -102,3 +146,4 @@ export const radiosSchema = zod.object({
 });
 
 export type RadiosProps = zod.infer<typeof radiosSchema>;
+export type RadioProps = zod.infer<typeof radioSchema>;

--- a/packages/html/ds/src/radio/radio.stories.ts
+++ b/packages/html/ds/src/radio/radio.stories.ts
@@ -1,254 +1,94 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Size, Tag } from '../heading/heading.schema';
 import { renderComponent } from '../storybook/storybook';
-import { InputTypeEnum } from '../text-input/text-input.schema';
-import type { RadiosProps } from './radio.schema';
-import html from './radios-group.html?raw';
+import html from './radio.html?raw';
+import type { RadioProps } from './radio.schema';
 
 // Name of the folder the macro resides
 const path = import.meta.url.split('/radio')[0];
 
-const macro = { name: 'govieRadiosGroup', html, path };
+const macro = { name: 'govieRadio', html, path };
 
-const Radios = renderComponent<RadiosProps>(macro);
-
-const standardProps = {
-  fieldId: 'uniqueId',
-  title: {
-    value: 'Where do you live?',
-    asHeading: {
-      size: Size.Medium,
-      as: Tag.H2,
-    },
-  },
-  items: [
-    {
-      label: 'England',
-      value: 'england',
-    },
-    {
-      label: 'Scotland',
-      value: 'scotland',
-    },
-    {
-      label: 'Ireland',
-      value: 'ireland',
-    },
-  ],
-};
+const Radio = renderComponent<RadioProps>(macro);
 
 const meta = {
-  component: Radios,
-  title: 'form/Radios',
+  component: Radio,
+  title: 'form/Radio/Radio',
   parameters: {
     macro,
     docs: {
       description: {
-        component:
-          'Radio component when users can only select one option from a list.',
+        component: 'Radio component',
       },
     },
   },
-} satisfies Meta<typeof Radios>;
+} satisfies Meta<typeof Radio>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   argTypes: {
-    fieldId: {
+    value: {
       control: 'text',
-      type: { name: 'string', required: true },
-      description: 'The unique value for the radios group',
+      type: 'string',
+      description: 'The value of the Component',
     },
-    items: {
-      control: 'object',
-      type: {
-        name: 'object',
-        required: true,
-        value: {
-          label: {
-            name: 'string',
-          },
-          value: {
-            name: 'string',
-            required: true,
-          },
-          hint: {
-            name: 'string',
-          },
-          conditionalInput: {
-            name: 'other',
-            value:
-              'Conditional input associated with the radio (see text input component)',
-          },
-        },
-      },
+    name: {
+      control: 'text',
+      type: 'string',
+      description: 'Name attribute of the input element',
+    },
+    label: {
+      control: 'text',
+      type: 'string',
+      description: 'The label associated with the Radio',
+    },
+    hint: {
+      control: 'text',
+      type: 'string',
       description:
-        'A list of the label, values, hint and conditional for the radios',
+        'Additional text to inform the user about the Radio component',
     },
-    inline: {
-      control: 'boolean',
-      description: 'Specify if the radios should be inline',
-    },
-    errorMessage: {
+    id: {
       control: 'text',
-      type: { name: 'string' },
-      description: 'The text of the error message',
-    },
-    title: {
-      control: 'object',
-      type: {
-        name: 'object',
-        value: {
-          value: {
-            name: 'string',
-          },
-          asHeading: {
-            name: 'boolean',
-          },
-          hint: {
-            name: 'string',
-          },
-        },
-      },
-      description: 'The label, hint and option the make the title a heading',
+      type: 'string',
+      description: 'The id of the Radio',
     },
     size: {
       control: 'radio',
       options: ['lg', 'md', 'sm'],
-      description: 'The sizes of the checkboxes',
+      description: 'The sizes for the Radio',
+    },
+
+    checked: {
+      control: 'boolean',
+      description: 'if true the component is checked',
     },
   },
   args: {
-    ...standardProps,
-    fieldId: 'UniqueId1',
+    value: 'radio-value',
+    label: 'Radio',
   },
 };
 
-export const inline: Story = {
+export const withHint: Story = {
   args: {
-    ...standardProps,
-    fieldId: 'UniqueId2',
-    inline: true,
+    value: 'radio-with-hint',
+    label: 'With hint',
+    hint: 'This is a hint',
   },
 };
 
-export const withTitleHint: Story = {
+export const withDefaultChecked: Story = {
   args: {
-    ...standardProps,
-    title: {
-      value: 'Where do you live?',
-      hint: 'Specify the location where you live',
-      asHeading: {
-        size: Size.Medium,
-        as: Tag.H2,
-      },
-    },
-    fieldId: 'UniqueId3',
+    value: 'radio-with-default-checked',
+    label: 'Default checked',
+    checked: true,
   },
 };
 
-export const withOptionHints: Story = {
+export const withoutLabel: Story = {
   args: {
-    title: {
-      value: 'Have you changed your name?',
-      hint: 'This includes changing your last name or spelling your name differently.',
-      asHeading: {
-        size: Size.Medium,
-        as: Tag.H2,
-      },
-    },
-    items: [
-      {
-        label: 'Yes',
-        value: 'no',
-        hint: 'Yes, I have changed my name',
-      },
-      {
-        label: 'No',
-        value: 'no',
-        hint: "No, I didn't change my name",
-      },
-    ],
-    fieldId: 'UniqueId4',
-  },
-};
-
-export const withDividerOption: Story = {
-  args: {
-    ...standardProps,
-    dividerOption: {
-      label: 'None of the above',
-      value: 'none of the above',
-    },
-    fieldId: 'UniqueId5',
-  },
-};
-
-export const withError: Story = {
-  args: {
-    ...standardProps,
-    errorMessage: 'Please select an option',
-    fieldId: 'UniqueId6',
-  },
-};
-
-export const withConditionalInput: Story = {
-  args: {
-    title: {
-      value: 'How would you prefer to be contacted?',
-      asHeading: {
-        size: Size.Medium,
-        as: Tag.H2,
-      },
-    },
-    items: [
-      {
-        label: 'Email',
-        value: 'email',
-        conditionalInput: {
-          id: 'input-id-email',
-          label: {
-            content: 'Email address',
-            for: 'input-id-email',
-          },
-          type: InputTypeEnum.Email,
-        },
-      },
-      {
-        label: 'Phone',
-        value: 'phone',
-        conditionalInput: {
-          id: 'input-id-phone',
-          label: {
-            content: 'Phone number',
-            for: 'input-id-phone',
-          },
-          type: InputTypeEnum.Tel,
-        },
-      },
-    ],
-    fieldId: 'UniqueId7',
-  },
-};
-
-export const withNoTitle: Story = {
-  args: {
-    fieldId: 'uniqueId8',
-    items: [
-      {
-        label: 'England',
-        value: 'england',
-      },
-      {
-        label: 'Scotland',
-        value: 'scotland',
-      },
-      {
-        label: 'Ireland',
-        value: 'ireland',
-      },
-    ],
+    value: 'radio-without-label',
   },
 };

--- a/packages/html/ds/src/radio/radio.test.ts
+++ b/packages/html/ds/src/radio/radio.test.ts
@@ -4,7 +4,7 @@ import { type RadiosProps, RadioSizeEnum } from './radio.schema';
 import html from './radios-group.html?raw';
 
 const standardProps = {
-  fieldId: 'uniqueId',
+  groupId: 'uniqueId',
   title: {
     value: 'Where do you live?',
     asHeading: {

--- a/packages/html/ds/src/radio/radio.ts
+++ b/packages/html/ds/src/radio/radio.ts
@@ -7,15 +7,25 @@ import {
 export type RadioOptions = BaseComponentOptions;
 
 export class Radio extends BaseComponent<RadioOptions> {
+  container: HTMLElement;
   getAllRadioInputs: NodeListOf<HTMLInputElement>;
+  defaultValue: string | undefined;
   renderConditionalInput: () => void;
 
   constructor(options: RadioOptions) {
     super(options);
+    this.container = this.options.element as HTMLElement;
+    this.defaultValue = this.container.dataset.defaultValue;
 
-    this.getAllRadioInputs = document.querySelectorAll(
+    this.getAllRadioInputs = this.container.querySelectorAll(
       'input[data-primary="true"]',
     );
+
+    for (const radio of this.getAllRadioInputs) {
+      if (radio.value === this.defaultValue) {
+        radio.checked = true;
+      }
+    }
 
     this.renderConditionalInput = () => {
       for (const radio of this.getAllRadioInputs) {

--- a/packages/html/ds/src/radio/radios-group.html
+++ b/packages/html/ds/src/radio/radios-group.html
@@ -6,8 +6,9 @@
 
 {% macro govieRadiosGroup(props) %}
   {% set isInline = 'gi-radio-group-options-inline' if props.inline else 'gi-radio-group-options-stacked' %}
-
+  {% set defaultValue = props.defaultValue if props.defaultValue else 'null' %}
   <div
+    data-default-value="{{ defaultValue }}"
     data-testid="govie-radios"
     data-module="gieds-radios"
     class="gi-radio-group-container"

--- a/packages/html/ds/src/radio/radios-group.html
+++ b/packages/html/ds/src/radio/radios-group.html
@@ -56,11 +56,12 @@
           {% for radio in props['items'] %}
             {{
               govieRadio({
-              "name": props.fieldId,
+              "checked": radio.checked,
+              "name": props.groupId,
               "label": radio.label,
               "value": radio.value,
               "hint": radio.hint,
-              "radioId": props.fieldId + "-" + loop.index0 | string,
+              "radioId": props.groupId + "-" + loop.index0 | string,
               "size": props.size,
               "dataElement": "radio" + loop.index0 | string,
               "conditionalInput": radio.conditionalInput
@@ -75,11 +76,12 @@
             </p>
             {{
               govieRadio({
-                "name": props.fieldId,
+                "checked": props.dividerOption.checked,
+                "name": props.groupId,
                 "label": props.dividerOption.label,
                 "value": props.dividerOption.value,
                 "hint": props.dividerOption.hint,
-                "radioId": props.fieldId + "-" + props.items.length | string,
+                "radioId": props.groupId + "-" + props.items.length | string,
                 "size": props.size,
                 "dataElement": "radio-divider-option",
                 "conditionalInput": props.dividerOption.conditionalInput

--- a/packages/react/ds/src/index.ts
+++ b/packages/react/ds/src/index.ts
@@ -33,6 +33,7 @@ export * from './button/button.js';
 export * from './tag/tag.js';
 export * from './modal/modal.js';
 export * from './radio/radios-group.js';
+export { Radio } from './radio/radio.js';
 export * from './card/card.js';
 export * from './cookie-banner/cookie-banner.js';
 export * from './list/list.js';

--- a/packages/react/ds/src/radio/radio-group.stories.tsx
+++ b/packages/react/ds/src/radio/radio-group.stories.tsx
@@ -1,0 +1,304 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RadiosGroup } from './radios-group.js';
+import type { RadiosGroupType } from './types.js';
+
+const standardProps: RadiosGroupType = {
+  groupId: 'uniqueId',
+  title: {
+    value: 'Where do you live?',
+    asHeading: {
+      size: 'md',
+      as: 'h2',
+    },
+  },
+  items: [
+    {
+      label: 'England',
+      value: 'england',
+    },
+    {
+      label: 'Scotland',
+      value: 'scotland',
+    },
+    {
+      label: 'Ireland',
+      value: 'ireland',
+    },
+  ],
+};
+
+const meta = {
+  title: 'Form/Radio/RadioGroup',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Radio group component when users can only select one option.',
+      },
+    },
+  },
+  component: RadiosGroup,
+} satisfies Meta<typeof RadiosGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  argTypes: {
+    groupId: {
+      control: 'text',
+      type: { name: 'string', required: true },
+      description: 'The unique value for the radios group',
+    },
+    items: {
+      control: 'object',
+      type: {
+        name: 'object',
+        required: true,
+        value: {
+          label: {
+            name: 'string',
+          },
+          value: {
+            name: 'string',
+            required: true,
+          },
+          hint: {
+            name: 'string',
+          },
+          conditionalInput: {
+            name: 'other',
+            value:
+              'Conditional input associated with the radio (see text input component)',
+          },
+        },
+      },
+      description:
+        'A list of the label, values, hint and conditional for the radios',
+    },
+    inline: {
+      control: 'boolean',
+      description: 'Specify if the radios should be inline',
+    },
+    errorMessage: {
+      control: 'text',
+      type: { name: 'string' },
+      description: 'The text of the error message',
+    },
+    title: {
+      control: 'object',
+      type: {
+        name: 'object',
+        value: {
+          value: {
+            name: 'string',
+          },
+          asHeading: {
+            name: 'boolean',
+          },
+          hint: {
+            name: 'string',
+          },
+        },
+      },
+      description: 'The label, hint and option the make the title a heading',
+    },
+    size: {
+      control: 'radio',
+      options: ['lg', 'md', 'sm'],
+      description: 'The sizes of the checkboxes',
+    },
+    onChange: {
+      control: 'object',
+      type: 'function',
+      description: 'Callback fired when a radio input is selected.',
+    },
+  },
+  args: {
+    ...standardProps,
+    groupId: 'UniqueId1',
+  },
+};
+
+export const inline: Story = {
+  args: {
+    ...standardProps,
+    groupId: 'UniqueId2',
+    inline: true,
+  },
+};
+
+export const withTitleHint: Story = {
+  args: {
+    ...standardProps,
+    title: {
+      value: 'Where do you live?',
+      hint: 'Specify the location where you live',
+      asHeading: {
+        size: 'md',
+        as: 'h2',
+      },
+    },
+    groupId: 'UniqueId3',
+  },
+};
+
+export const withOptionHints: Story = {
+  args: {
+    title: {
+      value: 'Have you changed your name?',
+      hint: 'This includes changing your last name or spelling your name differently.',
+      asHeading: {
+        size: 'md',
+        as: 'h2',
+      },
+    },
+    items: [
+      {
+        label: 'Yes',
+        value: 'yes',
+        hint: 'Yes, I have changed my name',
+      },
+      {
+        label: 'No',
+        value: 'no',
+        hint: "No, I didn't change my name",
+      },
+    ],
+    groupId: 'UniqueId4',
+  },
+};
+
+export const withDividerOption: Story = {
+  args: {
+    ...standardProps,
+    dividerOption: {
+      label: 'None of the above',
+      value: 'none of the above',
+    },
+    groupId: 'UniqueId5',
+  },
+};
+
+export const withError: Story = {
+  args: {
+    ...standardProps,
+    errorMessage: 'Please select an option',
+    groupId: 'UniqueId6',
+  },
+};
+
+export const withConditionalInput: Story = {
+  args: {
+    title: {
+      value: 'How would you prefer to be contacted?',
+      asHeading: {
+        size: 'md',
+        as: 'h2',
+      },
+    },
+    items: [
+      {
+        label: 'Email',
+        value: 'email',
+        conditionalInput: {
+          id: 'input-id-email',
+          label: {
+            text: 'Email address',
+          },
+          type: 'email',
+        },
+      },
+      {
+        label: 'Phone',
+        value: 'phone',
+        conditionalInput: {
+          id: 'input-id-phone',
+          label: {
+            text: 'Phone number',
+          },
+          type: 'tel',
+        },
+      },
+    ],
+    groupId: 'UniqueId7',
+  },
+};
+
+export const withNoTitle: Story = {
+  args: {
+    groupId: 'uniqueId8',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+      {
+        label: 'Scotland',
+        value: 'scotland',
+      },
+      {
+        label: 'Ireland',
+        value: 'ireland',
+      },
+    ],
+  },
+};
+
+export const singleRadio: Story = {
+  args: {
+    groupId: 'uniqueId9',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+    ],
+  },
+};
+
+export const withDefaultChecked: Story = {
+  args: {
+    groupId: 'uniqueId10',
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+      {
+        label: 'Scotland',
+        value: 'scotland',
+      },
+      {
+        label: 'Ireland',
+        value: 'ireland',
+        checked: true,
+      },
+    ],
+  },
+};
+
+export const withCallback: Story = {
+  args: {
+    groupId: 'uniqueId11',
+    onChange: (event) => {
+      setTimeout(() => {
+        alert(`You have selected ${event?.target.value}`);
+      });
+    },
+    items: [
+      {
+        label: 'England',
+        value: 'england',
+      },
+      {
+        label: 'Scotland',
+        value: 'scotland',
+      },
+      {
+        label: 'Ireland',
+        value: 'ireland',
+      },
+    ],
+  },
+};

--- a/packages/react/ds/src/radio/radio-group.stories.tsx
+++ b/packages/react/ds/src/radio/radio-group.stories.tsx
@@ -272,9 +272,9 @@ export const withDefaultChecked: Story = {
       {
         label: 'Ireland',
         value: 'ireland',
-        checked: true,
       },
     ],
+    defaultValue: 'ireland',
   },
 };
 

--- a/packages/react/ds/src/radio/radio.stories.tsx
+++ b/packages/react/ds/src/radio/radio.stories.tsx
@@ -1,241 +1,92 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { RadiosGroup } from './radios-group.js';
-import type { RadiosGroupType } from './types.js';
-
-const standardProps: RadiosGroupType = {
-  fieldId: 'uniqueId',
-  title: {
-    value: 'Where do you live?',
-    asHeading: {
-      size: 'md',
-      as: 'h2',
-    },
-  },
-  items: [
-    {
-      label: 'England',
-      value: 'england',
-    },
-    {
-      label: 'Scotland',
-      value: 'scotland',
-    },
-    {
-      label: 'Ireland',
-      value: 'ireland',
-    },
-  ],
-};
+import { Radio } from './radio.js';
 
 const meta = {
-  title: 'Form/Radios',
+  title: 'Form/Radio/Radio',
   parameters: {
     docs: {
       description: {
-        component:
-          'Radio component when users can only select one option from a list.',
+        component: 'Radio component',
       },
     },
   },
-  component: RadiosGroup,
-} satisfies Meta<typeof RadiosGroup>;
+  component: Radio,
+} satisfies Meta<typeof Radio>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   argTypes: {
-    fieldId: {
+    value: {
       control: 'text',
-      type: { name: 'string', required: true },
-      description: 'The unique value for the radios group',
+      type: 'string',
+      description: 'The value of the Component',
     },
-    items: {
-      control: 'object',
-      type: {
-        name: 'object',
-        required: true,
-        value: {
-          label: {
-            name: 'string',
-          },
-          value: {
-            name: 'string',
-            required: true,
-          },
-          hint: {
-            name: 'string',
-          },
-          conditionalInput: {
-            name: 'other',
-            value:
-              'Conditional input associated with the radio (see text input component)',
-          },
-        },
-      },
+    name: {
+      control: 'text',
+      type: 'string',
+      description: 'Name attribute of the input element',
+    },
+    label: {
+      control: 'text',
+      type: 'string',
+      description: 'The label associated with the Radio',
+    },
+    hint: {
+      control: 'text',
+      type: 'string',
       description:
-        'A list of the label, values, hint and conditional for the radios',
+        'Additional text to inform the user about the Radio component',
     },
-    inline: {
-      control: 'boolean',
-      description: 'Specify if the radios should be inline',
-    },
-    errorMessage: {
+    id: {
       control: 'text',
-      type: { name: 'string' },
-      description: 'The text of the error message',
-    },
-    title: {
-      control: 'object',
-      type: {
-        name: 'object',
-        value: {
-          value: {
-            name: 'string',
-          },
-          asHeading: {
-            name: 'boolean',
-          },
-          hint: {
-            name: 'string',
-          },
-        },
-      },
-      description: 'The label, hint and option the make the title a heading',
+      type: 'string',
+      description: 'The id of the Radio',
     },
     size: {
       control: 'radio',
       options: ['lg', 'md', 'sm'],
-      description: 'The sizes of the checkboxes',
+      description: 'The sizes for the Radio',
+    },
+    conditionalInput: {
+      description:
+        'Conditional input associated with the radio (see text input component)',
+    },
+    checked: {
+      control: 'boolean',
+      description: 'if true the component is checked',
+    },
+    onChange: {
+      control: 'object',
+      type: 'function',
+      description: 'Callback fired when the radio component is selected.',
     },
   },
   args: {
-    ...standardProps,
-    fieldId: 'UniqueId1',
+    value: 'radio-value',
+    label: 'Radio',
   },
 };
 
-export const inline: Story = {
+export const withHint: Story = {
   args: {
-    ...standardProps,
-    fieldId: 'UniqueId2',
-    inline: true,
+    value: 'radio-with-hint',
+    label: 'With hint',
+    hint: 'This is a hint',
   },
 };
 
-export const withTitleHint: Story = {
+export const withDefaultChecked: Story = {
   args: {
-    ...standardProps,
-    title: {
-      value: 'Where do you live?',
-      hint: 'Specify the location where you live',
-      asHeading: {
-        size: 'md',
-        as: 'h2',
-      },
-    },
-    fieldId: 'UniqueId3',
+    value: 'radio-with-default-checked',
+    label: 'Default checked',
+    checked: true,
   },
 };
 
-export const withOptionHints: Story = {
+export const withoutLabel: Story = {
   args: {
-    title: {
-      value: 'Have you changed your name?',
-      hint: 'This includes changing your last name or spelling your name differently.',
-      asHeading: {
-        size: 'md',
-        as: 'h2',
-      },
-    },
-    items: [
-      {
-        label: 'Yes',
-        value: 'yes',
-        hint: 'Yes, I have changed my name',
-      },
-      {
-        label: 'No',
-        value: 'no',
-        hint: "No, I didn't change my name",
-      },
-    ],
-    fieldId: 'UniqueId4',
-  },
-};
-
-export const withDividerOption: Story = {
-  args: {
-    ...standardProps,
-    dividerOption: {
-      label: 'None of the above',
-      value: 'none of the above',
-    },
-    fieldId: 'UniqueId5',
-  },
-};
-
-export const withError: Story = {
-  args: {
-    ...standardProps,
-    errorMessage: 'Please select an option',
-    fieldId: 'UniqueId6',
-  },
-};
-
-export const withConditionalInput: Story = {
-  args: {
-    title: {
-      value: 'How would you prefer to be contacted?',
-      asHeading: {
-        size: 'md',
-        as: 'h2',
-      },
-    },
-    items: [
-      {
-        label: 'Email',
-        value: 'email',
-        conditionalInput: {
-          id: 'input-id-email',
-          label: {
-            text: 'Email address',
-          },
-          type: 'email',
-        },
-      },
-      {
-        label: 'Phone',
-        value: 'phone',
-        conditionalInput: {
-          id: 'input-id-phone',
-          label: {
-            text: 'Phone number',
-          },
-          type: 'tel',
-        },
-      },
-    ],
-    fieldId: 'UniqueId7',
-  },
-};
-
-export const withNoTitle: Story = {
-  args: {
-    fieldId: 'uniqueId8',
-    items: [
-      {
-        label: 'England',
-        value: 'england',
-      },
-      {
-        label: 'Scotland',
-        value: 'scotland',
-      },
-      {
-        label: 'Ireland',
-        value: 'ireland',
-      },
-    ],
+    value: 'radio-without-label',
   },
 };

--- a/packages/react/ds/src/radio/radio.test.tsx
+++ b/packages/react/ds/src/radio/radio.test.tsx
@@ -3,7 +3,7 @@ import { RadiosGroup } from './radios-group.js';
 import { type RadiosGroupType, RadiosSizeEnum } from './types.js';
 
 const standardProps: RadiosGroupType = {
-  fieldId: 'uniqueId',
+  groupId: 'uniqueId',
   title: {
     value: 'Where do you live?',
     asHeading: {

--- a/packages/react/ds/src/radio/radio.tsx
+++ b/packages/react/ds/src/radio/radio.tsx
@@ -41,12 +41,13 @@ export const Radio = ({
   label,
   value,
   hint,
-  radioId,
+  id,
   size,
   conditionalInput,
   checked,
   onChange,
 }: RadioProps) => {
+  const radioId = id ?? value;
   return (
     <div className="gi-radio-container">
       <div className="gi-radio-input-container">
@@ -66,7 +67,7 @@ export const Radio = ({
       {(hint || conditionalInput) && (
         <div className="gi-radio-conditional-divider-container">
           <div
-            className={`${addConditionalDivider(checked, conditionalInput)} ${getRadioWidth(size)}`}
+            className={`${addConditionalDivider((checked = false), conditionalInput)} ${getRadioWidth(size)}`}
           >
             <div
               className={`gi-radio-conditional-divider-border-container ${getRadioWidth(size)}`}

--- a/packages/react/ds/src/radio/radio.tsx
+++ b/packages/react/ds/src/radio/radio.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { HintText } from '../hint-text/hint-text.js';
-import { TextInput, TextInputProps } from '../text-input/text-input.js';
-import { RadioProps, RadiosSizeEnum } from './types.js';
+import { TextInput, type TextInputProps } from '../text-input/text-input.js';
+import { type RadioProps, RadiosSizeEnum } from './types.js';
 
 const getRadioSize = (size?: RadiosSizeEnum) => {
   let sizeClass = 'gi-radio-medium';
@@ -52,6 +52,7 @@ export const Radio = ({
     <div className="gi-radio-container">
       <div className="gi-radio-input-container">
         <input
+          readOnly={checked}
           onChange={onChange}
           checked={checked}
           name={name}
@@ -73,7 +74,7 @@ export const Radio = ({
             <div
               className={`gi-radio-conditional-divider-border-container ${getRadioWidth(size)}`}
             >
-              <div className="gi-radio-conditional-divider-border"></div>
+              <div className="gi-radio-conditional-divider-border" />
             </div>
           </div>
           <div>

--- a/packages/react/ds/src/radio/radio.tsx
+++ b/packages/react/ds/src/radio/radio.tsx
@@ -59,6 +59,7 @@ export const Radio = ({
           value={value}
           className={`gi-radio-base ${getRadioSize(size)}`}
           type="radio"
+          aria-label={radioId}
         />
         <label htmlFor={radioId} className="gi-radio-label">
           {label}

--- a/packages/react/ds/src/radio/radio.tsx
+++ b/packages/react/ds/src/radio/radio.tsx
@@ -27,10 +27,10 @@ export const getRadioWidth = (size?: RadiosSizeEnum) => {
 };
 
 const addConditionalDivider = (
-  checked: boolean,
   conditionalInput: TextInputProps | undefined,
+  checked?: boolean,
 ) => {
-  if (conditionalInput) {
+  if (conditionalInput && checked) {
     return checked ? 'gi-block' : 'gi-invisible';
   }
   return 'gi-invisible';
@@ -67,7 +67,7 @@ export const Radio = ({
       {(hint || conditionalInput) && (
         <div className="gi-radio-conditional-divider-container">
           <div
-            className={`${addConditionalDivider((checked = false), conditionalInput)} ${getRadioWidth(size)}`}
+            className={`${addConditionalDivider(conditionalInput, checked)} ${getRadioWidth(size)}`}
           >
             <div
               className={`gi-radio-conditional-divider-border-container ${getRadioWidth(size)}`}

--- a/packages/react/ds/src/radio/radios-group.tsx
+++ b/packages/react/ds/src/radio/radios-group.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ErrorText } from '../error-text/error-text.js';
 import { Heading } from '../heading/heading.js';
 import { HintText } from '../hint-text/hint-text.js';
@@ -15,20 +15,15 @@ export const RadiosGroup = ({
   dividerOption,
   title,
   onChange,
+  defaultValue,
 }: RadiosGroupType) => {
-  const [value, setValue] = useState<null | string>(null);
-
-  useEffect(() => {
-    for (const radio of items) {
-      if (radio.checked) {
-        setValue(radio.value);
-      }
-    }
-  }, []);
+  const initialValue =
+    items.find((radio) => radio.value === defaultValue)?.value ?? null;
+  const [value, setValue] = useState<null | string>(initialValue);
 
   const onOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
-    onChange && onChange(event);
+    onChange?.(event);
   };
 
   return (

--- a/packages/react/ds/src/radio/radios-group.tsx
+++ b/packages/react/ds/src/radio/radios-group.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ErrorText } from '../error-text/error-text.js';
 import { Heading } from '../heading/heading.js';
 import { HintText } from '../hint-text/hint-text.js';
@@ -7,18 +7,28 @@ import { Radio, getRadioWidth } from './radio.js';
 import type { RadiosGroupType } from './types.js';
 
 export const RadiosGroup = ({
-  fieldId,
+  groupId,
   items,
   inline,
   size,
   errorMessage,
   dividerOption,
   title,
+  onChange,
 }: RadiosGroupType) => {
   const [value, setValue] = useState<null | string>(null);
 
+  useEffect(() => {
+    for (const radio of items) {
+      if (radio.checked) {
+        setValue(radio.value);
+      }
+    }
+  }, []);
+
   const onOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
+    onChange && onChange(event);
   };
 
   return (
@@ -59,11 +69,11 @@ export const RadiosGroup = ({
                 key={`${value}-${index}`}
                 checked={value === radio.value}
                 onChange={onOptionChange}
-                name={fieldId}
+                name={groupId}
                 label={radio.label}
                 value={radio.value}
                 hint={radio.hint}
-                radioId={`${fieldId}-${index}`}
+                id={`${groupId}-${index}`}
                 size={size}
                 conditionalInput={radio.conditionalInput}
               />
@@ -80,11 +90,11 @@ export const RadiosGroup = ({
                 <Radio
                   checked={value === dividerOption.value}
                   onChange={onOptionChange}
-                  name={fieldId}
+                  name={groupId}
                   label={dividerOption.label}
                   value={dividerOption.value}
                   hint={dividerOption.hint}
-                  radioId={`${fieldId}-${items.length}`}
+                  id={`${groupId}-${items.length}`}
                   size={size}
                   conditionalInput={dividerOption.conditionalInput}
                 />

--- a/packages/react/ds/src/radio/radios-group.tsx
+++ b/packages/react/ds/src/radio/radios-group.tsx
@@ -61,7 +61,7 @@ export const RadiosGroup = ({
           >
             {items.map((radio, index) => (
               <Radio
-                key={`${value}-${index}`}
+                key={`${groupId}-${index}`}
                 checked={value === radio.value}
                 onChange={onOptionChange}
                 name={groupId}
@@ -83,6 +83,7 @@ export const RadiosGroup = ({
                   or
                 </p>
                 <Radio
+                  key={`${groupId}-${items.length}`}
                   checked={value === dividerOption.value}
                   onChange={onOptionChange}
                   name={groupId}

--- a/packages/react/ds/src/radio/types.ts
+++ b/packages/react/ds/src/radio/types.ts
@@ -26,8 +26,8 @@ export type RadiosGroupType = {
     label?: string;
     hint?: string;
     conditionalInput?: TextInputProps;
-    checked?: boolean;
   }[];
+  defaultValue?: string;
   inline?: boolean;
   size?: RadiosSizeEnum;
   errorMessage?: string;

--- a/packages/react/ds/src/radio/types.ts
+++ b/packages/react/ds/src/radio/types.ts
@@ -8,24 +8,25 @@ export enum RadiosSizeEnum {
 }
 
 export type RadioProps = {
-  name: string;
-  label?: string;
   value: string;
+  name?: string;
+  label?: string;
   hint?: string;
-  radioId: string;
+  id?: string;
   size?: RadiosSizeEnum;
   conditionalInput?: TextInputProps;
-  checked: boolean;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  checked?: boolean;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export type RadiosGroupType = {
-  fieldId: string;
+  groupId: string;
   items: {
     value: string;
     label?: string;
     hint?: string;
     conditionalInput?: TextInputProps;
+    checked?: boolean;
   }[];
   inline?: boolean;
   size?: RadiosSizeEnum;
@@ -44,4 +45,5 @@ export type RadiosGroupType = {
     };
     hint?: string;
   };
+  onChange?: (event?: React.ChangeEvent<HTMLInputElement>) => void;
 };

--- a/packages/react/storybook/.storybook/preview.tsx
+++ b/packages/react/storybook/.storybook/preview.tsx
@@ -2,14 +2,35 @@ import {
   INITIAL_VIEWPORTS,
   MINIMAL_VIEWPORTS,
 } from '@storybook/addon-viewport';
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  Controls,
+  Stories,
+} from '@storybook/blocks';
 import type { Preview } from '@storybook/react';
 import '@govie-ds/react/styles.css';
 import '@govie-ds/theme-govie/theme.css';
 import './global.css';
 import '../../ds/styles.css';
+import React from 'react';
 
 const preview: Preview = {
   parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+          <Stories includePrimary={false} />
+        </>
+      ),
+    },
     a11y: {
       options: {},
     },


### PR DESCRIPTION
Implementation of the following:

- Expose the `Radio` Component
- Add the following props:
1.   `checked` -> if `true` the input is checked by default
2.  `onChange` --> callback function
- Rename the prop `fieldId` to `groupId`
- Add stories for the `Radio` Component

The above applies to the Macro and React libraries

**SB screenshots**
![Screenshot 2024-11-12 at 10 02 22](https://github.com/user-attachments/assets/bf4fa44d-02d2-4a4c-a5bb-b6d96a1c2718)
1d33f26)
![Screenshot 2024-11-12 at 10 02 54](https://github.com/user-attachments/assets/3b40a270-8b73-48c9-85fe-363dfe92f5fe)


