### PR TITLE
fix: change order of scripts

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "format": "prettier 'src/**/*.{ts,tsx}' --write",
     "format:check": "prettier 'src/**/*.{ts,tsx}' --check",
     "dev": "pnpm build:styles && next dev",
-    "build": "pnpm build:site && pnpm build:styles",
+    "build": "pnpm build:styles && pnpm build:site",
     "build:site": "next build",
     "build:styles": "node ./scripts/copy-html-ds.js && cross-env USE_RESOLVED_THEME=true tailwindcss build -i ./src/app/globals.css -o ./public/styles.css",
     "build:export": "cross-env NEXT_EXPORT=true next build",


### PR DESCRIPTION
change the order of the scripts that run in the `build` process so that it copies the styles for macros and then create the optimized build