### PR TITLE
fix: remove prefix for dev environment

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,22 +1,14 @@
 import { withContentlayer } from 'next-contentlayer';
 
-const isGitHubPages = Boolean(process.env.GITHUB_PAGES);
 const isNextExport = Boolean(process.env.NEXT_EXPORT);
-
-const prefix = isGitHubPages ? '/govie-ds' : undefined;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
-  basePath: prefix,
-  assetPrefix: prefix,
   output: isNextExport ? 'export' : 'standalone',
   images: {
     unoptimized: true, // TODO: review image optimisation
-  },
-  publicRuntimeConfig: {
-    basePath: prefix,
   },
 };
 

--- a/apps/docs/public/templates/search-page.html
+++ b/apps/docs/public/templates/search-page.html
@@ -5,7 +5,6 @@
     <title>Home</title>
     <link rel="stylesheet" href="theme.css" />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="stylesheet" href="/static/css/ogcio-ds-0.4.4.min.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       *,
@@ -2057,7 +2056,7 @@
       </div>
     </footer>
 
-    <script src="/static/js/govie-frontend.umd.js"></script>
+    <script src="/govie-frontend.umd.js"></script>
     <div class="notyf"></div>
     <div
       class="notyf-announcer"

--- a/apps/docs/src/components/document/common/image.tsx
+++ b/apps/docs/src/components/document/common/image.tsx
@@ -1,10 +1,7 @@
 import NextImage, { ImageProps } from 'next/image';
-import { config } from '@/lib/config';
 
 export function Image(props: ImageProps) {
-  const imageSource = config.isGitHubPages()
-    ? `/govie-ds${props.src}`
-    : props.src;
+  const imageSource = props.src;
 
   return <NextImage {...props} src={imageSource} />;
 }

--- a/apps/docs/src/lib/config.ts
+++ b/apps/docs/src/lib/config.ts
@@ -5,7 +5,6 @@ function isProduction() {
 }
 
 export type DocumentSiteConfiguration = {
-  isGitHubPages: () => boolean;
   showDrafts: () => boolean;
   buildingBlocksHomeUrl: string;
   feedbackFormUrl: string;
@@ -23,7 +22,6 @@ function getConfiguration(
   environment: DocumentSiteEnvironment,
 ): DocumentSiteConfiguration {
   const defaultConfiguration: DocumentSiteConfiguration = {
-    isGitHubPages: () => process.env.GITHUB_PAGES === 'true',
     showDrafts: () => {
       // Show drafts setting takes precedence
       if (process.env.NEXT_PUBLIC_SHOW_DRAFTS) {


### PR DESCRIPTION
Because on dev environment we have a `govie-ds` prefixed on routes, the iframes renders are failing. Aligning the dev environments with the higher environments so that the routes will be the same