### PR TITLE
feat: add react tooltip component

### DIFF
--- a/apps/docs/content/3-components/2-library/tooltip.mdx
+++ b/apps/docs/content/3-components/2-library/tooltip.mdx
@@ -9,22 +9,70 @@ libraries:
   - platform: 'global'
     status: 'considering'
   - platform: 'react'
-    status: 'considering'
+    status: 'beta'
+    link: ?path=/docs/application-tooltip--docs'
 ---
 
 # Tooltip
 
-## Variants
+## Default
+
+<Tooltip label="Default Tooltip" position="top">
+  <Button variant="primary">Hover me (Top)</Button>
+</Tooltip>
 
 ## Usage
 
+<Tabs id="tab1">
+  <TabList>
+    <TabItem value="tab11">HTML</TabItem>
+    <TabItem value="tab12">Macro</TabItem>
+    <TabItem value="tab13" checked>React</TabItem>
+  </TabList>
+  <TabPanel value="tab11">
+  TBD
+  </TabPanel>
+  <TabPanel value="tab12">
+  TBD
+  </TabPanel>
+  <TabPanel value="tab13">
+    ```jsx
+    import { Tooltip, Button } from '@govie-ds/react';
+
+    <Tooltip
+      label="Default Tooltip"
+      position="top"
+    >
+      <Button variant="primary">
+        Hover me (Top)
+      </Button>
+    </Tooltip>
+
+    ```
+
+  </TabPanel>
+</Tabs>
+
 ### Best Practices
+
+- Keep the tooltip content concise and relevant. Tooltips are meant for brief contextual information.
+- Avoid overloading tooltips with large amounts of text or complex HTML structures.
+- Ensure the tooltip is accessible by providing appropriate ARIA attributes (`aria-label`, `aria-describedby`).
+- Use tooltips sparingly to avoid overwhelming users with excessive hover points.
+- Test tooltips on touch devices to ensure they don't obstruct essential UI elements.
 
 ### When to use this component
 
+- Use tooltips to provide additional information or context for UI elements without cluttering the interface.
+- Ideal for explaining icons, abbreviations, or buttons that might not be immediately clear to the user.
+- When information is supplementary and doesn’t require the user's immediate action.
+
 ### When not to use this component
+
+- Do not use tooltips for essential information critical to completing a task. Place such information directly in the UI.
+- Avoid using tooltips on elements that users interact with on touch devices, as hover actions are less intuitive or non-functional.
+- Refrain from placing tooltips in rapid action areas where users might not have time to hover over elements.
 
 ## Status
 
 <ComponentStatusBlock componentId="tooltip" />
-

--- a/apps/docs/content/3-components/2-library/tooltip.mdx
+++ b/apps/docs/content/3-components/2-library/tooltip.mdx
@@ -17,9 +17,11 @@ libraries:
 
 ## Default
 
-<Tooltip label="Default Tooltip" position="top">
-  <Button variant="primary">Hover me (Top)</Button>
-</Tooltip>
+<ComponentContainer>
+  <Tooltip label="Default Tooltip" position="top">
+    <Button variant="primary">Hover me (Top)</Button>
+  </Tooltip>
+</ComponentContainer>
 
 ## Usage
 

--- a/apps/docs/dictionary.txt
+++ b/apps/docs/dictionary.txt
@@ -140,3 +140,6 @@ Bia
 Carlow
 Cavan
 summarisable
+tooltip
+tooltips
+Tooltips

--- a/apps/docs/src/components/document/common/mdx.tsx
+++ b/apps/docs/src/components/document/common/mdx.tsx
@@ -49,6 +49,7 @@ import {
   TableData,
   TableBody,
   Link,
+  Tooltip,
 } from '@govie-ds/react';
 import { MDXComponents } from 'mdx/types';
 import { useMDXComponent } from 'next-contentlayer/hooks';
@@ -226,6 +227,7 @@ const documentComponents: MDXComponents = {
   TableRow: (props) => <TableRow {...props} />,
   TableData: (props) => <TableData {...props} />,
   TableBody: (props) => <TableBody {...props} />,
+  Tooltip: (props) => <Tooltip {...props} />,
 };
 
 export function Mdx({ code }: MdxProps) {

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -1047,3 +1047,44 @@ input[type='file' i] {
 }
 
 /* End of Table */
+.gi-tooltip-wrapper {
+  @apply gi-relative gi-inline-block gi-overflow-visible gi-text-lg;
+}
+
+.gi-tooltip {
+  @apply gi-absolute gi-z-[100] gi-bg-gray-900 gi-text-sm gi-text-white gi-px-4 gi-py-2 gi-rounded-[10px] gi-whitespace-nowrap gi-opacity-100 gi-transition-opacity gi-duration-300;
+}
+
+.gi-tooltip-wrapper .gi-tooltip-top {
+  @apply gi-bottom-full gi-left-1/2 gi-translate-x-[-50%] gi-translate-y-[-0.75rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-top::after {
+  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] gi-border-x-[9px] gi-border-x-transparent gi-border-t-[9px] gi-border-t-gray-900 gi-bottom-[-0.45rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-bottom {
+  @apply gi-top-full gi-left-1/2 gi-translate-x-[-50%] gi-translate-y-[0.75rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-bottom::after {
+  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] gi-border-x-[9px] gi-border-x-transparent gi-border-b-[9px] gi-border-b-gray-900 gi-top-[-0.45rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-left {
+  @apply gi-right-full gi-top-1/2 gi-translate-y-[-50%] gi-translate-x-[-0.75rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-left::after {
+  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] gi-border-y-[9px] gi-border-y-transparent gi-border-l-[9px] gi-border-l-gray-900 gi-right-[-0.45rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-right {
+  @apply gi-left-full gi-top-1/2 gi-translate-y-[-50%] gi-translate-x-[0.75rem];
+}
+
+.gi-tooltip-wrapper .gi-tooltip-right::after {
+  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] gi-border-y-[9px] gi-border-y-transparent gi-border-r-[9px] gi-border-r-gray-900 gi-left-[-0.45rem];
+}
+
+/* End of Tooltip */

--- a/packages/react/ds/src/index.ts
+++ b/packages/react/ds/src/index.ts
@@ -51,3 +51,4 @@ export * from './pagination/pagination.js';
 export * from './breadcrumbs/breadcrumbs.js';
 export * from './summary-list/summary-list.js';
 export * from './progress-stepper/progress-stepper.js';
+export * from './tooltip/tooltip.js';

--- a/packages/react/ds/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.stories.tsx
@@ -92,8 +92,7 @@ export const RightPosition: Story = {
 
 export const WithLongLabel: Story = {
   args: {
-    label:
-      'This is a very long tooltip label that tests the tooltip display and its styling when the label spans multiple lines.',
+    label: 'This is a very long tooltip label that tests the tooltip display.',
     position: 'top',
     children: <Button variant="primary">Hover me (Top)</Button>,
   },

--- a/packages/react/ds/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Tooltip from './tooltip.js';
 import { Button } from '../button/button.js';
+import { Tooltip } from './tooltip.js';
 
 const meta = {
   title: 'Components/Tooltip',

--- a/packages/react/ds/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Tooltip from './tooltip.js';
+import { Button } from '../button/button.js';
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The Tooltip component displays a label when the user hovers over the wrapped element. The `label` prop defines the text, and the `position` prop specifies the tooltip position (`top`, `bottom`, `left`, or `right`).',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      description: 'The text displayed in the tooltip.',
+      control: 'text',
+      table: {
+        category: 'Props',
+        type: { summary: 'string' },
+      },
+    },
+    position: {
+      description: 'Position of the tooltip relative to the child element.',
+      control: 'radio',
+      options: ['top', 'bottom', 'left', 'right'],
+      table: {
+        category: 'Props',
+        type: { summary: "'top' | 'bottom' | 'left' | 'right'" },
+      },
+    },
+    children: {
+      description: 'The child element that triggers the tooltip on hover.',
+      control: false,
+      table: {
+        category: 'Props',
+        type: { summary: 'ReactNode' },
+      },
+    },
+  },
+  decorators: (Story) => (
+    <div className="gi-flex gi-justify-center gi-py-5 gi-px-5">
+      <Story />
+    </div>
+  ),
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'Default Tooltip',
+    position: 'top',
+    children: <Button variant="primary">Hover me (Top)</Button>,
+  },
+};
+
+export const TopPosition: Story = {
+  args: {
+    label: 'This is a tooltip at the top.',
+    position: 'top',
+    children: <Button variant="primary">Hover me (Top)</Button>,
+  },
+};
+
+export const BottomPosition: Story = {
+  args: {
+    label: 'This is a tooltip at the bottom.',
+    position: 'bottom',
+    children: <Button variant="primary">Hover me (Bottom)</Button>,
+  },
+};
+
+export const LeftPosition: Story = {
+  args: {
+    label: 'This is a tooltip on the left.',
+    position: 'left',
+    children: <Button variant="primary">Hover me (Left)</Button>,
+  },
+};
+
+export const RightPosition: Story = {
+  args: {
+    label: 'This is a tooltip on the right.',
+    position: 'right',
+    children: <Button variant="primary">Hover me (Right)</Button>,
+  },
+};
+
+export const WithLongLabel: Story = {
+  args: {
+    label:
+      'This is a very long tooltip label that tests the tooltip display and its styling when the label spans multiple lines.',
+    position: 'top',
+    children: <Button variant="primary">Hover me (Top)</Button>,
+  },
+};

--- a/packages/react/ds/src/tooltip/tooltip.test.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { cleanup, render, fireEvent } from '../test-utils.js';
+import { Tooltip } from './tooltip.js';
+
+describe('govieTooltip', () => {
+  afterEach(cleanup);
+
+  const renderTooltip = (props: React.ComponentProps<typeof Tooltip>) =>
+    render(<Tooltip {...props}>Hover me</Tooltip>);
+
+  it('should render the child component', () => {
+    const screen = renderTooltip({
+      label: 'Tooltip Text',
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+    const childElement = screen.getByText('Hover me');
+
+    expect(childElement).toBeTruthy();
+  });
+
+  it('should not show tooltip initially', () => {
+    const screen = renderTooltip({
+      label: 'Tooltip Text',
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+    const tooltipTextElement = screen.queryByText('Tooltip Text');
+
+    expect(tooltipTextElement).not.toBeInTheDocument();
+  });
+
+  it('should show tooltip on mouse enter', () => {
+    const screen = renderTooltip({
+      label: 'Tooltip Text',
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+    const wrapperElement = screen.getByText('Hover me');
+
+    fireEvent.mouseEnter(wrapperElement);
+
+    const tooltipTextElement = screen.getByText('Tooltip Text');
+    expect(tooltipTextElement).toBeInTheDocument();
+  });
+
+  it('should hide tooltip on mouse leave', () => {
+    const screen = renderTooltip({
+      label: 'Tooltip Text',
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+    const wrapperElement = screen.getByText('Hover me');
+
+    fireEvent.mouseEnter(wrapperElement);
+    const tooltipTextElement = screen.getByText('Tooltip Text');
+    expect(tooltipTextElement).toBeInTheDocument();
+
+    fireEvent.mouseLeave(wrapperElement);
+    expect(screen.queryByText('Tooltip Text')).not.toBeInTheDocument();
+  });
+
+  it.each(['top', 'bottom', 'left', 'right'] as const)(
+    'should apply correct position class for %s position',
+    (position) => {
+      const screen = renderTooltip({
+        label: 'Tooltip Text',
+        position,
+        children: <button>Hover me</button>,
+      });
+
+      fireEvent.mouseEnter(screen.getByText('Hover me'));
+
+      const tooltipElement = screen.getByText('Tooltip Text');
+      expect(tooltipElement).toHaveClass(`gi-tooltip-${position}`);
+    },
+  );
+
+  it('should render tooltip with correct text', () => {
+    const tooltipText = 'Test Tooltip Content';
+    const screen = renderTooltip({
+      label: tooltipText,
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+
+    fireEvent.mouseEnter(screen.getByText('Hover me'));
+
+    const tooltipTextElement = screen.getByText(tooltipText);
+    expect(tooltipTextElement).toBeInTheDocument();
+  });
+
+  it('should pass axe accessibility tests', async () => {
+    const screen = renderTooltip({
+      label: 'Accessibility Tooltip',
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+
+    await screen.axe();
+  });
+});

--- a/packages/react/ds/src/tooltip/tooltip.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, useId } from 'react';
+import { tv } from 'tailwind-variants';
 
 type TooltipProps = {
   label: string;
@@ -7,8 +8,25 @@ type TooltipProps = {
   children: ReactNode;
 };
 
-export const Tooltip = (props: TooltipProps) => {
+const tooltipTv = tv({
+  base: 'gi-tooltip',
+  variants: {
+    position: {
+      left: `gi-tooltip-left`,
+      right: `gi-tooltip-right`,
+      top: `gi-tooltip-top`,
+      bottom: `gi-tooltip-bottom`,
+    },
+  },
+});
+
+export const Tooltip = ({
+  label,
+  position = 'top',
+  children,
+}: TooltipProps) => {
   const [isVisible, setIsVisible] = useState(false);
+  const describedById = useId();
 
   const showTooltip = () => setIsVisible(true);
   const hideTooltip = () => setIsVisible(false);
@@ -18,11 +36,17 @@ export const Tooltip = (props: TooltipProps) => {
       className="gi-tooltip-wrapper"
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
+      aria-describedby={isVisible ? describedById : undefined}
     >
-      {props.children}
+      {children}
       {isVisible && (
-        <span className={`gi-tooltip gi-tooltip-${props.position}`}>
-          {props.label}
+        <span
+          id={describedById}
+          role="tooltip"
+          className={tooltipTv({ position })}
+          aria-hidden="false"
+        >
+          {label}
         </span>
       )}
     </span>

--- a/packages/react/ds/src/tooltip/tooltip.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { ReactNode, useState } from 'react';
+
+type TooltipProps = {
+  label: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+  children: ReactNode;
+};
+
+export const Tooltip = (props: TooltipProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const showTooltip = () => setIsVisible(true);
+  const hideTooltip = () => setIsVisible(false);
+
+  return (
+    <span
+      className="gi-tooltip-wrapper"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+    >
+      {props.children}
+      {isVisible && (
+        <span className={`gi-tooltip gi-tooltip-${props.position}`}>
+          {props.label}
+        </span>
+      )}
+    </span>
+  );
+};


### PR DESCRIPTION
- Addition of react tooltip component.
- Unit tests.
- Documentation update.
- Storybook update.
- 4 variants, top, bottom, left and right.

Storybook testing:
![Screenshot 2024-12-11 at 14 35 06](https://github.com/user-attachments/assets/74385235-93df-4459-acc5-6bc2197a2a1d)

