### PR TITLE
feat: add html and macro for tooltip

### DIFF
--- a/apps/docs/content/3-components/2-library/tooltip.mdx
+++ b/apps/docs/content/3-components/2-library/tooltip.mdx
@@ -11,7 +11,7 @@ libraries:
     link: '?path=/docs/application-tooltip--docs'
   - platform: 'react'
     status: 'beta'
-    link: ?path=/docs/application-tooltip--docs'
+    link: '?path=/docs/application-tooltip--docs'
 ---
 
 # Tooltip

--- a/apps/docs/content/3-components/2-library/tooltip.mdx
+++ b/apps/docs/content/3-components/2-library/tooltip.mdx
@@ -7,7 +7,8 @@ libraries:
     link: '?path=/docs/application-tooltip--docs'
     status: 'stable'
   - platform: 'global'
-    status: 'considering'
+    status: 'beta'
+    link: '?path=/docs/application-tooltip--docs'
   - platform: 'react'
     status: 'beta'
     link: ?path=/docs/application-tooltip--docs'
@@ -27,15 +28,42 @@ libraries:
 
 <Tabs id="tab1">
   <TabList>
-    <TabItem value="tab11">HTML</TabItem>
+    <TabItem value="tab11" checked>HTML</TabItem>
     <TabItem value="tab12">Macro</TabItem>
-    <TabItem value="tab13" checked>React</TabItem>
+    <TabItem value="tab13">React</TabItem>
   </TabList>
   <TabPanel value="tab11">
-  TBD
+  ```html
+    <span
+      class="gi-tooltip-wrapper"
+      data-module="gieds-tooltip"
+    >        
+      <button
+        data-testid="govieButton-default-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Default (Hover me)
+      </button>
+      <span 
+        role="tooltip" 
+        class="gi-tooltip gi-tooltip-top"
+        aria-hidden="true"
+      >
+        Tooltip right.
+      </span>
+    </span>
+  ```
   </TabPanel>
   <TabPanel value="tab12">
-  TBD
+    ```html
+    {{ govieTooltip({
+      "position": "top",
+      "text": "Tooltip right.",
+      "content": "\n    <button\n      data-testid=\"govieButton-default-primary-medium-notDisabled\"\n      data-element=\"button-container\"\n      data-module=\"gieds-button\"\n      class=\"gi-btn gi-btn-primary gi-btn-regular\"\n    >\n      Default (Hover me)\n    </button>"
+    }) }}
+    ```
   </TabPanel>
   <TabPanel value="tab13">
     ```jsx

--- a/examples/wagtail/core/jinja/home_page.jinja
+++ b/examples/wagtail/core/jinja/home_page.jinja
@@ -28,6 +28,7 @@
 {% from 'table/table.html' import govieTable %}
 {% from 'checkbox/checkbox.html' import govieCheckbox %}
 {% from 'checkbox/checkboxes-group.html' import govieCheckboxesGroup %}
+{% from 'tooltip/tooltip.html' import govieTooltip %}
 
 {% from 'vars.jinja' import checkboxesProps, comboBoxProps, cookieBannerProps, modalProps, footerProps, HeaderProps, SelectProps, tabsProps, radioProps, listProps %}
 
@@ -284,6 +285,13 @@
         govieProgressStepper({ "steps": [ "Step 1", "Step 2", "Step 3", "Step 4", "Step 5", "Step 6", "Step 7"], "currentStepIndex": 3, "orientation": "horizontal" })
     }}
   <br />
+
+  <h2>Tooltip (top)</h2>
+  {{ govieTooltip({
+    "position": "top",
+    "text": "Tooltip right.",
+    "content": "\n    <button\n      data-testid=\"govieButton-default-primary-medium-notDisabled\"\n      data-element=\"button-container\"\n      data-module=\"gieds-button\"\n      class=\"gi-btn gi-btn-primary gi-btn-regular\"\n    >\n      Default (Hover me)\n    </button>"
+  }) }}
 
   <h2>Basic Table</h2>
   {{ govieTable({

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -1062,6 +1062,14 @@ input[type='file' i] {
   @apply gi-absolute gi-z-[100] gi-bg-gray-900 gi-text-sm gi-text-white gi-px-4 gi-py-2 gi-rounded-[10px] gi-whitespace-nowrap gi-opacity-100 gi-transition-opacity gi-duration-300;
 }
 
+.gi-tooltip[aria-hidden='true'] {
+  @apply gi-hidden;
+}
+
+.gi-tooltip[aria-hidden='false'] {
+  @apply gi-block;
+}
+
 .gi-tooltip-wrapper .gi-tooltip-top {
   @apply gi-bottom-full gi-left-1/2 gi-translate-x-[-50%] gi-translate-y-[-0.75rem];
 }

--- a/packages/html/ds/src/common/instances.ts
+++ b/packages/html/ds/src/common/instances.ts
@@ -8,8 +8,8 @@ import { Modal } from '../modal/modal';
 import { Radio } from '../radio/radio';
 import { Tabs } from '../tabs/tabs';
 import { Textarea } from '../textarea/textarea';
-import { Tooltip } from '../tooltip/tooltip';
 import { Toast } from '../toast/toast';
+import { Tooltip } from '../tooltip/tooltip';
 import { BaseComponent, BaseComponentOptions } from './component';
 
 function generateRandomId() {

--- a/packages/html/ds/src/common/instances.ts
+++ b/packages/html/ds/src/common/instances.ts
@@ -8,6 +8,7 @@ import { Modal } from '../modal/modal';
 import { Radio } from '../radio/radio';
 import { Tabs } from '../tabs/tabs';
 import { Textarea } from '../textarea/textarea';
+import { Tooltip } from '../tooltip/tooltip';
 import { Toast } from '../toast/toast';
 import { BaseComponent, BaseComponentOptions } from './component';
 
@@ -20,6 +21,7 @@ const componentRegistry = {
   Checkboxes,
   Radio,
   Textarea,
+  Tooltip,
   Modal,
   CookieBanner,
   Tabs,

--- a/packages/html/ds/src/index.ts
+++ b/packages/html/ds/src/index.ts
@@ -10,8 +10,8 @@ import { initModal } from './modal/modal.js';
 import { initRadios } from './radio/radio.js';
 import { initTabs } from './tabs/tabs.js';
 import { initTextarea } from './textarea/textarea.js';
-import { initTooltip } from './tooltip/tooltip.js';
 import { initToast } from './toast/toast.js';
+import { initTooltip } from './tooltip/tooltip.js';
 
 export * as properties from './dist/properties.js';
 

--- a/packages/html/ds/src/index.ts
+++ b/packages/html/ds/src/index.ts
@@ -10,6 +10,7 @@ import { initModal } from './modal/modal.js';
 import { initRadios } from './radio/radio.js';
 import { initTabs } from './tabs/tabs.js';
 import { initTextarea } from './textarea/textarea.js';
+import { initTooltip } from './tooltip/tooltip.js';
 import { initToast } from './toast/toast.js';
 
 export * as properties from './dist/properties.js';
@@ -33,6 +34,7 @@ export function initGovIe() {
   initCheckboxes();
   initRadios();
   initTextarea();
+  initTooltip();
   initModal();
   initCookieBanner();
   initTabs();

--- a/packages/html/ds/src/tooltip/tooltip.html
+++ b/packages/html/ds/src/tooltip/tooltip.html
@@ -1,0 +1,17 @@
+{% macro govieTooltip(props) %}
+    <span
+      class="gi-tooltip-wrapper"
+      {% if props.ariaDescribedBy %} aria-describedby="{{ props.ariaDescribedBy }}"{% endif %}
+    >
+        {% if props.content %}
+            {{ props.content | safe }}
+        {% endif %}
+        <span 
+          role="tooltip" 
+          class="gi-tooltip gi-tooltip-{{ props.position }}"
+          aria-hidden="true"
+        >
+            {{ props.text }}
+        </span>
+    </span>
+{% endmacro %}

--- a/packages/html/ds/src/tooltip/tooltip.html
+++ b/packages/html/ds/src/tooltip/tooltip.html
@@ -1,18 +1,18 @@
 {% macro govieTooltip(props) %}
+  <span
+    class="gi-tooltip-wrapper"
+    data-module="gieds-tooltip"
+    {% if props.ariaDescribedBy %}aria-describedby="{{ props.ariaDescribedBy }}"{% endif %}
+  >
+    {% if props.content %}
+      {{ props.content | safe }}
+    {% endif %}
     <span
-      class="gi-tooltip-wrapper"
-      data-module="gieds-tooltip"
-      {% if props.ariaDescribedBy %} aria-describedby="{{ props.ariaDescribedBy }}"{% endif %}
+      role="tooltip"
+      class="gi-tooltip gi-tooltip-{{ props.position }}"
+      aria-hidden="true"
     >
-        {% if props.content %}
-            {{ props.content | safe }}
-        {% endif %}
-        <span 
-          role="tooltip" 
-          class="gi-tooltip gi-tooltip-{{ props.position }}"
-          aria-hidden="true"
-        >
-            {{ props.text }}
-        </span>
+      {{ props.text }}
     </span>
+  </span>
 {% endmacro %}

--- a/packages/html/ds/src/tooltip/tooltip.html
+++ b/packages/html/ds/src/tooltip/tooltip.html
@@ -1,6 +1,7 @@
 {% macro govieTooltip(props) %}
     <span
       class="gi-tooltip-wrapper"
+      data-module="gieds-tooltip"
       {% if props.ariaDescribedBy %} aria-describedby="{{ props.ariaDescribedBy }}"{% endif %}
     >
         {% if props.content %}

--- a/packages/html/ds/src/tooltip/tooltip.schema.ts
+++ b/packages/html/ds/src/tooltip/tooltip.schema.ts
@@ -1,0 +1,38 @@
+import * as zod from 'zod';
+
+export const tooltipSchema = zod.object({
+  text: zod
+    .string({
+      description: 'The main text or content of the tooltip.',
+    }),
+  content: zod
+    .union([
+      zod.string({
+        description: 'Optional content to be wrapped by the tooltip.',
+      }),
+      zod.null(),
+    ])
+    .optional(),
+  position: zod
+    .enum(['top', 'bottom', 'left', 'right'], {
+      description: 'Defines the position of the tooltip relative to the target element.',
+    })
+    .default('top'),
+  id: zod
+    .string({
+      description: 'Sets the ID for the tooltip, used for accessibility.',
+    })
+    .optional(),
+  ariaLabel: zod
+    .string({
+      description: 'Provides an accessible name for the tooltip.',
+    })
+    .optional(),
+  ariaDescribedBy: zod
+    .string({
+      description: 'Provides an accessible aria described by property for the tooltip.',
+    })
+    .optional(),
+});
+
+export type TooltipProps = zod.infer<typeof tooltipSchema>;

--- a/packages/html/ds/src/tooltip/tooltip.schema.ts
+++ b/packages/html/ds/src/tooltip/tooltip.schema.ts
@@ -1,10 +1,9 @@
 import * as zod from 'zod';
 
 export const tooltipSchema = zod.object({
-  text: zod
-    .string({
-      description: 'The main text or content of the tooltip.',
-    }),
+  text: zod.string({
+    description: 'The main text or content of the tooltip.',
+  }),
   content: zod
     .union([
       zod.string({
@@ -15,7 +14,8 @@ export const tooltipSchema = zod.object({
     .optional(),
   position: zod
     .enum(['top', 'bottom', 'left', 'right'], {
-      description: 'Defines the position of the tooltip relative to the target element.',
+      description:
+        'Defines the position of the tooltip relative to the target element.',
     })
     .default('top'),
   id: zod
@@ -30,7 +30,8 @@ export const tooltipSchema = zod.object({
     .optional(),
   ariaDescribedBy: zod
     .string({
-      description: 'Provides an accessible aria described by property for the tooltip.',
+      description:
+        'Provides an accessible aria described by property for the tooltip.',
     })
     .optional(),
 });

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { renderComponent } from '../storybook/storybook';
 import html from './tooltip.html?raw';
 import { TooltipProps } from './tooltip.schema';
+import { useEffect } from 'react';
+import { destroyGovIe, initGovIe } from '..';
 
 const path = import.meta.url.split('/tooltip')[0];
 
@@ -14,11 +16,40 @@ const meta = {
     macro,
     docs: {
       description: {
-        component: 'Tooltip'
+        component:
+          'The Tooltip component displays a label when the user hovers over the wrapped element. The `label` prop defines the text, and the `position` prop specifies the tooltip position (`top`, `bottom`, `left`, or `right`).',
+      },
+    },
+  },
+  argTypes: {
+    text: {
+      description: 'The text displayed in the tooltip.',
+      control: 'text',
+      table: {
+        category: 'Props',
+        type: { summary: 'string' },
+      },
+    },
+    position: {
+      description: 'Position of the tooltip relative to the child element.',
+      control: 'radio',
+      options: ['top', 'bottom', 'left', 'right'],
+      table: {
+        category: 'Props',
+        type: { summary: "'top' | 'bottom' | 'left' | 'right'" },
+      },
+    },
+    content: {
+      description: 'The HTML content that will be wrapped by the tooltip.',
+      control: 'text',
+      table: {
+        category: 'Props',
+        type: { summary: 'HTMLString' },
       },
     },
   },
   component: Tooltip,
+  
 } satisfies Meta<typeof Tooltip>;
 
 export default meta;
@@ -26,7 +57,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    position: 'right',
+    position: 'top',
     text: 'Tooltip right.',
     content: `
     <button
@@ -37,5 +68,90 @@ export const Default: Story = {
     >
       Default (Hover me)
     </button>`
+  },
+};
+
+export const TopPosition: Story = {
+  args: {
+    text: 'This is a tooltip at the top.',
+    position: 'top',
+    content: `
+      <button
+        data-testid="govieButton-top-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Hover me (Top)
+      </button>
+    `,
+  },
+};
+
+export const BottomPosition: Story = {
+  args: {
+    text: 'This is a tooltip at the bottom.',
+    position: 'bottom',
+    content: `
+      <button
+        data-testid="govieButton-bottom-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Hover me (Bottom)
+      </button>
+    `,
+  },
+};
+
+export const LeftPosition: Story = {
+  args: {
+    text: 'This is a tooltip on the left.',
+    position: 'left',
+    content: `
+      <button
+        data-testid="govieButton-left-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Hover me (Left)
+      </button>
+    `,
+  },
+};
+
+export const RightPosition: Story = {
+  args: {
+    text: 'This is a tooltip on the right.',
+    position: 'right',
+    content: `
+      <button
+        data-testid="govieButton-right-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Hover me (Right)
+      </button>
+    `,
+  },
+};
+
+export const WithLongLabel: Story = {
+  args: {
+    text: 'This is a very long tooltip label that tests the tooltip display.',
+    position: 'top',
+    content: `
+      <button
+        data-testid="govieButton-long-primary-medium-notDisabled"
+        data-element="button-container"
+        data-module="gieds-button"
+        class="gi-btn gi-btn-primary gi-btn-regular"
+      >
+        Hover me (Top)
+      </button>
+    `,
   },
 };

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -9,7 +9,7 @@ const macro = { name: 'govieTooltip', html, path };
 const Tooltip = renderComponent<TooltipProps>(macro);
 
 const meta = {
-  title: 'Components/Tooltip',
+  title: 'Application/Tooltip',
   parameters: {
     macro,
     docs: {

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { renderComponent } from '../storybook/storybook';
 import html from './tooltip.html?raw';
 import { TooltipProps } from './tooltip.schema';
-import { useEffect } from 'react';
-import { destroyGovIe, initGovIe } from '..';
 
 const path = import.meta.url.split('/tooltip')[0];
 
@@ -49,7 +47,6 @@ const meta = {
     },
   },
   component: Tooltip,
-  
 } satisfies Meta<typeof Tooltip>;
 
 export default meta;
@@ -67,7 +64,7 @@ export const Default: Story = {
       class="gi-btn gi-btn-primary gi-btn-regular"
     >
       Default (Hover me)
-    </button>`
+    </button>`,
   },
 };
 

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { renderComponent } from '../storybook/storybook';
+import html from './tooltip.html?raw';
+import { TooltipProps } from './tooltip.schema';
+
+const path = import.meta.url.split('/tooltip')[0];
+
+const macro = { name: 'govieTooltip', html, path };
+const Tooltip = renderComponent<TooltipProps>(macro);
+
+const meta = {
+  title: 'Components/Tooltip',
+  parameters: {
+    macro,
+    docs: {
+      description: {
+        component: 'Tooltip'
+      },
+    },
+  },
+  component: Tooltip,
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    position: 'right',
+    text: 'Tooltip right.',
+    content: `
+    <button
+      data-testid="govieButton-default-primary-medium-notDisabled"
+      data-element="button-container"
+      data-module="gieds-button"
+      class="gi-btn gi-btn-primary gi-btn-regular"
+    >
+      Default (Hover me)
+    </button>`
+  },
+};

--- a/packages/html/ds/src/tooltip/tooltip.test.ts
+++ b/packages/html/ds/src/tooltip/tooltip.test.ts
@@ -1,0 +1,88 @@
+import { render } from '../common/render';
+import html from './tooltip.html?raw';
+import { TooltipProps } from './tooltip.schema';
+
+describe('govieTooltip', () => {
+  const renderTooltip = render<TooltipProps>({
+    componentName: 'tooltip',
+    macroName: 'govieTooltip',
+    html,
+  });
+
+  it('should render the tooltip wrapper', () => {
+    const screen = renderTooltip({
+      content: '<button>Hover me</button>',
+      text: 'Tooltip text',
+      position: 'top',
+    });
+
+    const wrapper = screen.getByRole('button').closest('.gi-tooltip-wrapper');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.classList.contains('gi-tooltip-wrapper')).toBe(true);
+  });
+
+  it('should render the tooltip with correct role and position', () => {
+    const screen = renderTooltip({
+      content: '<button>Hover me</button>',
+      text: 'Tooltip text',
+      position: 'bottom',
+    });
+  
+    const tooltip = screen.getByText('Tooltip text');
+    expect(tooltip).toBeTruthy();
+    expect(tooltip.classList.contains('gi-tooltip-bottom')).toBe(true);
+  });
+
+  it('should set aria-hidden to true by default', () => {
+    const screen = renderTooltip({
+      text: 'Tooltip text',
+      position: 'top',
+    });
+
+    const tooltip = screen.getByText('Tooltip text');
+    expect(tooltip.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('should apply aria-describedby to the wrapper if provided', () => {
+    const screen = renderTooltip({
+      text: 'Tooltip text',
+      position: 'right',
+      ariaDescribedBy: 'described-by-id',
+    });
+
+    const wrapper = screen.getByText('Tooltip text').closest('.gi-tooltip-wrapper');
+    expect(wrapper?.getAttribute('aria-describedby')).toBe('described-by-id');
+  });
+
+  it('should not set aria-describedby if not provided', () => {
+    const screen = renderTooltip({
+      text: 'Tooltip text',
+      position: 'top',
+    });
+
+    const wrapper = screen.getByText('Tooltip text').closest('.gi-tooltip-wrapper');
+    expect(wrapper?.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('should render the wrapped content', () => {
+    const screen = renderTooltip({
+      content: '<button>Hover me</button>',
+      text: 'Tooltip text',
+      position: 'top',
+    });
+
+    const button = screen.getByRole('button');
+    expect(button).toBeTruthy();
+    expect(button.textContent).toBe('Hover me');
+  });
+
+  it('should pass axe accessibility tests', async () => {
+    const screen = renderTooltip({
+      content: '<button>Hover me</button>',
+      text: 'Tooltip text',
+      position: 'top',
+    });
+
+    await screen.axe();
+  });
+});

--- a/packages/html/ds/src/tooltip/tooltip.test.ts
+++ b/packages/html/ds/src/tooltip/tooltip.test.ts
@@ -27,7 +27,7 @@ describe('govieTooltip', () => {
       text: 'Tooltip text',
       position: 'bottom',
     });
-  
+
     const tooltip = screen.getByText('Tooltip text');
     expect(tooltip).toBeTruthy();
     expect(tooltip.classList.contains('gi-tooltip-bottom')).toBe(true);
@@ -50,7 +50,9 @@ describe('govieTooltip', () => {
       ariaDescribedBy: 'described-by-id',
     });
 
-    const wrapper = screen.getByText('Tooltip text').closest('.gi-tooltip-wrapper');
+    const wrapper = screen
+      .getByText('Tooltip text')
+      .closest('.gi-tooltip-wrapper');
     expect(wrapper?.getAttribute('aria-describedby')).toBe('described-by-id');
   });
 
@@ -60,7 +62,9 @@ describe('govieTooltip', () => {
       position: 'top',
     });
 
-    const wrapper = screen.getByText('Tooltip text').closest('.gi-tooltip-wrapper');
+    const wrapper = screen
+      .getByText('Tooltip text')
+      .closest('.gi-tooltip-wrapper');
     expect(wrapper?.hasAttribute('aria-describedby')).toBe(false);
   });
 

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -10,7 +10,6 @@ export class Tooltip extends BaseComponent<TooltipProps> {
   getAllTooltips: NodeListOf<HTMLElement>;
 
   constructor(options: TooltipProps) {
-
     super(options);
     this.getAllTooltips = document.querySelectorAll('.gi-tooltip-wrapper');
 
@@ -21,7 +20,9 @@ export class Tooltip extends BaseComponent<TooltipProps> {
     const wrapper = event.currentTarget as HTMLElement;
     const tooltip = wrapper.querySelector('[role="tooltip"]');
 
-    if (!wrapper || !tooltip) return;
+    if (!wrapper || !tooltip) {
+      return
+    };
 
     if (event.type === 'mouseenter') {
       tooltip.setAttribute('aria-hidden', 'false');
@@ -32,22 +33,30 @@ export class Tooltip extends BaseComponent<TooltipProps> {
 
   initComponent() {
     for (const tooltipWrapper of this.getAllTooltips) {
-      tooltipWrapper.addEventListener('mouseenter', this.handleTooltipVisibility, false);
-      tooltipWrapper.addEventListener('mouseleave', this.handleTooltipVisibility, false);
+      tooltipWrapper.addEventListener(
+        'mouseenter',
+        this.handleTooltipVisibility,
+        false,
+      );
+      tooltipWrapper.addEventListener(
+        'mouseleave',
+        this.handleTooltipVisibility,
+        false,
+      );
     }
   }
 
   destroyComponent(): void {
     for (const tooltipWrapper of this.getAllTooltips) {
       tooltipWrapper.removeEventListener(
-        'mouseenter', 
-        this.handleTooltipVisibility, 
-        false
+        'mouseenter',
+        this.handleTooltipVisibility,
+        false,
       );
       tooltipWrapper.removeEventListener(
-        'mouseleave', 
-        this.handleTooltipVisibility, 
-        false
+        'mouseleave',
+        this.handleTooltipVisibility,
+        false,
       );
     }
   }

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -21,8 +21,8 @@ export class Tooltip extends BaseComponent<TooltipProps> {
     const tooltip = wrapper.querySelector('[role="tooltip"]');
 
     if (!wrapper || !tooltip) {
-      return
-    };
+      return;
+    }
 
     if (event.type === 'mouseenter') {
       tooltip.setAttribute('aria-hidden', 'false');

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -1,0 +1,59 @@
+import {
+  BaseComponent,
+  BaseComponentOptions,
+  initialiseModule,
+} from '../common/component';
+
+export type TooltipProps = BaseComponentOptions;
+
+export class Tooltip extends BaseComponent<TooltipProps> {
+  getAllTooltips: NodeListOf<HTMLElement>;
+
+  constructor(options: TooltipProps) {
+
+    super(options);
+    this.getAllTooltips = document.querySelectorAll('.gi-tooltip-wrapper');
+
+    this.handleTooltipVisibility = this.handleTooltipVisibility.bind(this);
+  }
+
+  handleTooltipVisibility(event: MouseEvent) {
+    const wrapper = event.currentTarget as HTMLElement;
+    const tooltip = wrapper.querySelector('[role="tooltip"]');
+
+    if (!wrapper || !tooltip) return;
+
+    if (event.type === 'mouseenter') {
+      tooltip.setAttribute('aria-hidden', 'false');
+    } else if (event.type === 'mouseleave') {
+      tooltip.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  initComponent() {
+    for (const tooltipWrapper of this.getAllTooltips) {
+      tooltipWrapper.addEventListener('mouseenter', this.handleTooltipVisibility, false);
+      tooltipWrapper.addEventListener('mouseleave', this.handleTooltipVisibility, false);
+    }
+  }
+
+  destroyComponent(): void {
+    for (const tooltipWrapper of this.getAllTooltips) {
+      tooltipWrapper.removeEventListener(
+        'mouseenter', 
+        this.handleTooltipVisibility, 
+        false
+      );
+      tooltipWrapper.removeEventListener(
+        'mouseleave', 
+        this.handleTooltipVisibility, 
+        false
+      );
+    }
+  }
+}
+
+export const initTooltip = initialiseModule({
+  name: 'tooltip',
+  component: 'Tooltip',
+});

--- a/packages/html/storybook/.storybook/preview.tsx
+++ b/packages/html/storybook/.storybook/preview.tsx
@@ -22,6 +22,11 @@ const Decorator = (arguments_, parameters) => {
     }
     return classes;
   }
+
+  if (parameters?.macro?.name === 'govieTooltip') {
+    return 'gi-flex gi-justify-center gi-py-5 gi-px-5';
+  }
+
   if (parameters?.macro?.name === 'govieSpinner') {
     return 'gi-stroke-gray-950';
   }

--- a/packages/react/ds/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.stories.tsx
@@ -3,7 +3,7 @@ import { Button } from '../button/button.js';
 import { Tooltip } from './tooltip.js';
 
 const meta = {
-  title: 'Components/Tooltip',
+  title: 'Application/Tooltip',
   component: Tooltip,
   parameters: {
     docs: {


### PR DESCRIPTION
Addition of:

- Tooltip HTML and jinja macro.
- Documentation update.
- Testing.
- Example page update.
- Tooltip instance initialised.
- Root level decorator for tooltip.

Documentation site:

![Screenshot 2024-12-16 at 11 13 58](https://github.com/user-attachments/assets/25ffba47-4a50-4b01-a43a-dfb10369ce74)
