### PR TITLE
poc: aria attributes for button 

### DIFF
--- a/packages/html/ds/src/button/button-schema.ts
+++ b/packages/html/ds/src/button/button-schema.ts
@@ -31,6 +31,13 @@ export enum ButtonType {
   Button = 'button',
 }
 
+ export const ariaSchema = zod.record(
+  zod.string({
+    description: 'ARIA attributes key-value pairs',
+  }),
+  { description: 'An object of ARIA attributes' }
+).optional();
+
 export const buttonSchema = zod.object({
   content: zod.string({
     description: 'The raw HTML that will be inserted',
@@ -66,6 +73,7 @@ export const buttonSchema = zod.object({
       description: 'The value for the button sent in the request',
     })
     .optional(),
+  aria: ariaSchema
 });
 
 export type ButtonProps = zod.infer<typeof buttonSchema>;

--- a/packages/html/ds/src/button/button.html
+++ b/packages/html/ds/src/button/button.html
@@ -1,3 +1,4 @@
+{% from 'common/aria-attributes.html' import commonAriaAttributes %}
 {% from 'button/helpers.html' import getVariantAppearanceClass, getSizeClass, isButtonDisabled %}
 
 {% macro govieButton(props) %}
@@ -29,6 +30,7 @@
     </a>
   {% else %}
     <button
+      {{ commonAriaAttributes(props) }}
       {% if props.type %}type="{{ props.type }}"{% endif %}
       {% if props.form %}form="{{ props.form }}"{% endif %}
       {% if props.value %}value="{{ props.value }}"{% endif %}

--- a/packages/html/ds/src/button/button.stories.ts
+++ b/packages/html/ds/src/button/button.stories.ts
@@ -155,6 +155,9 @@ export const Disabled: Story = {
   args: {
     disabled: true,
     content: `Button`,
+    aria: {
+      disabled: 'true',
+    }
   },
 };
 

--- a/packages/html/ds/src/button/button.test.ts
+++ b/packages/html/ds/src/button/button.test.ts
@@ -132,6 +132,26 @@ describe('button', () => {
     expect(buttonElement).toBeTruthy();
   });
 
+  it('should render aria attributes correctly', () => {
+    const propsWithAria = {
+      ...standardProps,
+      aria: {
+        disabled: 'true',
+        expanded: 'false',
+        controls: 'menu1',
+      },
+    };
+    
+    const screen = renderButton(propsWithAria);
+    
+    // Check if ARIA attributes are rendered correctly
+    const buttonElement = screen.getByText(standardProps.content);
+    
+    expect(buttonElement).toHaveAttribute('aria-disabled', 'true');
+    expect(buttonElement).toHaveAttribute('aria-expanded', 'false');
+    expect(buttonElement).toHaveAttribute('aria-controls', 'menu1');
+  });
+
   it('should pass axe tests', async () => {
     const screen = renderButton(standardProps);
     await screen.axe();

--- a/packages/html/ds/src/common/aria-attributes.html
+++ b/packages/html/ds/src/common/aria-attributes.html
@@ -1,0 +1,7 @@
+{% macro commonAriaAttributes(props) %}
+  {% if props.aria %}
+    {% for key, value in props.aria %}
+      {{ 'aria-' ~ key }}="{{ value }}"
+    {% endfor %}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This PR focuses on:

- POC for adding aria attributes on button using a helper created in common.
- Associated testing and schema.

Testing:

![Screenshot 2025-01-02 at 17 29 59](https://github.com/user-attachments/assets/6aa0fc77-50b0-476d-9e73-541c390f8666)
![Screenshot 2025-01-02 at 17 30 20](https://github.com/user-attachments/assets/d564c074-eeda-4243-9ca1-ab2c54b6c78d)
