### PR TITLE
docs: update summary list row display name on storybook

### DIFF
--- a/packages/react/ds/src/summary-list/summary-list.tsx
+++ b/packages/react/ds/src/summary-list/summary-list.tsx
@@ -43,4 +43,6 @@ export const SummaryList = ({ children }: SummaryListProps) => {
   );
 };
 
-SummaryListRow.displayName = 'SummaryList';
+SummaryList.displayName = 'SummaryList';
+SummaryListRow.displayName = 'SummaryRow';
+SummaryListAction.displayName = 'SummaryListAction';


### PR DESCRIPTION
Testing done locally on storybook:
<img width="863" alt="Screenshot 2025-01-27 at 17 46 44" src="https://github.com/user-attachments/assets/6f567f5c-f9d8-4235-a435-60cb85674e8e" />
