### PR TITLE
fix: update common aria attributes

### DIFF
--- a/packages/html/ds/src/common/aria-attributes.html
+++ b/packages/html/ds/src/common/aria-attributes.html
@@ -1,6 +1,6 @@
 {% macro commonAriaAttributes(props) %}
-  {% if props.aria %}
-    {% for key, value in props.aria %}
+  {% if props.aria and props.aria.items %}
+    {% for key, value in props.aria.items() %}
       {{ key }}="{{ value }}"
     {% endfor %}
   {% endif %}

--- a/packages/html/ds/src/common/aria-attributes.html
+++ b/packages/html/ds/src/common/aria-attributes.html
@@ -1,5 +1,5 @@
 {% macro commonAriaAttributes(props) %}
-  {% if props.aria  %}
+  {% if props.aria %}
     {% for key, value in props.aria | items %}
       {{ key }}="{{ value }}"
     {% endfor %}

--- a/packages/html/ds/src/common/aria-attributes.html
+++ b/packages/html/ds/src/common/aria-attributes.html
@@ -1,6 +1,6 @@
 {% macro commonAriaAttributes(props) %}
-  {% if props.aria and props.aria.items %}
-    {% for key, value in props.aria.items() %}
+  {% if props.aria  %}
+    {% for key, value in props.aria | items %}
       {{ key }}="{{ value }}"
     {% endfor %}
   {% endif %}

--- a/packages/html/ds/src/link/link.html
+++ b/packages/html/ds/src/link/link.html
@@ -46,7 +46,7 @@
           "type": props.asButton.type,
           "form": props.asButton.form,
           "value": props.asButton.value,
-          "aria": props.asButton.aria
+          "aria": props.aria
         })
       }}
     {% else %}

--- a/packages/html/macro/src/macro.ts
+++ b/packages/html/macro/src/macro.ts
@@ -25,6 +25,10 @@ function createNunjucksEnvironment(path = '') {
 
   environment.addGlobal('validateProperties', validateProperties);
 
+  environment.addFilter('items', function (obj) {
+    return Object.entries(obj);
+  });
+
   return environment;
 }
 

--- a/packages/html/macro/src/macro.ts
+++ b/packages/html/macro/src/macro.ts
@@ -25,8 +25,8 @@ function createNunjucksEnvironment(path = '') {
 
   environment.addGlobal('validateProperties', validateProperties);
 
-  environment.addFilter('items', function (obj) {
-    return Object.entries(obj);
+  environment.addFilter('items', function (object) {
+    return Object.entries(object);
   });
 
   return environment;


### PR DESCRIPTION
- The built-in `items()` function is not being currently read by the python environment, so ended up by creating a custom `items` pipe.
- Without `items` pipe, Jinja tries to unpack the keys of the dictionary into key, value, which leads to the error.