### PR TITLE
fix: update tooltip with escape and focus functionality

### DIFF
--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -1229,8 +1229,15 @@ input[type='file' i] {
 }
 
 /* End of Progress bar*/
+
+/* Tooltip */
 .gi-tooltip-wrapper {
   @apply gi-relative gi-inline-block gi-overflow-visible gi-text-lg;
+}
+
+/* Focus ring for the wrapper or its focusable children */
+.gi-tooltip-wrapper:focus-within {
+  @apply gi-ring-2 gi-ring-blue-500 gi-ring-offset-2 gi-rounded-sm;
 }
 
 .gi-tooltip {
@@ -1245,12 +1252,14 @@ input[type='file' i] {
   @apply gi-block;
 }
 
+/* Position variants */
 .gi-tooltip-wrapper .gi-tooltip-top {
   @apply gi-bottom-full gi-left-1/2 gi-translate-x-[-50%] gi-translate-y-[-0.75rem];
 }
 
 .gi-tooltip-wrapper .gi-tooltip-top::after {
-  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] gi-border-x-[9px] gi-border-x-transparent gi-border-t-[9px] gi-border-t-gray-900 gi-bottom-[-0.45rem];
+  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] 
+         gi-border-x-[9px] gi-border-x-transparent gi-border-t-[9px] gi-border-t-gray-900 gi-bottom-[-0.45rem];
 }
 
 .gi-tooltip-wrapper .gi-tooltip-bottom {
@@ -1258,7 +1267,8 @@ input[type='file' i] {
 }
 
 .gi-tooltip-wrapper .gi-tooltip-bottom::after {
-  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] gi-border-x-[9px] gi-border-x-transparent gi-border-b-[9px] gi-border-b-gray-900 gi-top-[-0.45rem];
+  @apply gi-content-[''] gi-absolute gi-left-1/2 gi-translate-x-[-50%] 
+         gi-border-x-[9px] gi-border-x-transparent gi-border-b-[9px] gi-border-b-gray-900 gi-top-[-0.45rem];
 }
 
 .gi-tooltip-wrapper .gi-tooltip-left {
@@ -1266,7 +1276,8 @@ input[type='file' i] {
 }
 
 .gi-tooltip-wrapper .gi-tooltip-left::after {
-  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] gi-border-y-[9px] gi-border-y-transparent gi-border-l-[9px] gi-border-l-gray-900 gi-right-[-0.45rem];
+  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] 
+         gi-border-y-[9px] gi-border-y-transparent gi-border-l-[9px] gi-border-l-gray-900 gi-right-[-0.45rem];
 }
 
 .gi-tooltip-wrapper .gi-tooltip-right {
@@ -1274,7 +1285,7 @@ input[type='file' i] {
 }
 
 .gi-tooltip-wrapper .gi-tooltip-right::after {
-  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] gi-border-y-[9px] gi-border-y-transparent gi-border-r-[9px] gi-border-r-gray-900 gi-left-[-0.45rem];
+  @apply gi-content-[''] gi-absolute gi-top-1/2 gi-translate-y-[-50%] 
+         gi-border-y-[9px] gi-border-y-transparent gi-border-r-[9px] gi-border-r-gray-900 gi-left-[-0.45rem];
 }
-
 /* End of Tooltip */

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -1236,7 +1236,7 @@ input[type='file' i] {
 }
 
 .gi-tooltip {
-  @apply gi-absolute gi-z-[100] gi-bg-gray-900 gi-text-sm gi-text-white gi-px-4 gi-py-2 gi-rounded-[10px] gi-whitespace-nowrap gi-opacity-100 gi-transition-opacity gi-duration-300;
+  @apply gi-absolute gi-z-[100] gi-bg-gray-900 gi-text-sm gi-text-white gi-px-4 gi-py-2 gi-rounded-[10px] gi-opacity-100 gi-transition-opacity gi-duration-300 gi-w-max gi-text-center gi-max-w-[300px];
 }
 
 .gi-tooltip[aria-hidden='true'] {

--- a/packages/design/tailwind/css/components.css
+++ b/packages/design/tailwind/css/components.css
@@ -1235,11 +1235,6 @@ input[type='file' i] {
   @apply gi-relative gi-inline-block gi-overflow-visible gi-text-lg;
 }
 
-/* Focus ring for the wrapper or its focusable children */
-.gi-tooltip-wrapper:focus-within {
-  @apply gi-ring-2 gi-ring-blue-500 gi-ring-offset-2 gi-rounded-sm;
-}
-
 .gi-tooltip {
   @apply gi-absolute gi-z-[100] gi-bg-gray-900 gi-text-sm gi-text-white gi-px-4 gi-py-2 gi-rounded-[10px] gi-whitespace-nowrap gi-opacity-100 gi-transition-opacity gi-duration-300;
 }

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -53,7 +53,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     position: 'top',
-    text: 'Tooltip right.',
+    text: 'Tooltip top with a very large text. Help me out her to figure out the max width. Maybe try reading the ticket information',
     content: `
     <button
       data-testid="govieButton-default-primary-medium-notDisabled"

--- a/packages/html/ds/src/tooltip/tooltip.stories.ts
+++ b/packages/html/ds/src/tooltip/tooltip.stories.ts
@@ -53,7 +53,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     position: 'top',
-    text: 'Tooltip top with a very large text. Help me out her to figure out the max width. Maybe try reading the ticket information',
+    text: 'This is a tooltip at the top.',
     content: `
     <button
       data-testid="govieButton-default-primary-medium-notDisabled"
@@ -136,8 +136,8 @@ export const RightPosition: Story = {
 
 export const WithLongLabel: Story = {
   args: {
-    text: 'This is a very long tooltip label that tests the tooltip display.',
-    position: 'top',
+    text: 'This is a very long tooltip text that tests the tooltip display. This is a very long tooltip text that tests the tooltip display.',
+    position: 'right',
     content: `
       <button
         data-testid="govieButton-long-primary-medium-notDisabled"
@@ -145,7 +145,7 @@ export const WithLongLabel: Story = {
         data-module="gieds-button"
         class="gi-btn gi-btn-primary gi-btn-regular"
       >
-        Hover me (Top)
+        Hover me (Right)
       </button>
     `,
   },

--- a/packages/html/ds/src/tooltip/tooltip.test.ts
+++ b/packages/html/ds/src/tooltip/tooltip.test.ts
@@ -91,6 +91,17 @@ describe('govieTooltip', () => {
     expect(button.textContent).toBe('Hover me');
   });
 
+  it('should render ellipsis for long text', () => {
+    const screen = renderTooltip({
+      content: '<button>Hover me</button>',
+      text: 'Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip text.',
+      position: 'top',
+    });
+
+    const tooltip = screen.getByText('Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip tex...');
+    expect(tooltip).toBeTruthy();
+  });
+
   it('should pass axe accessibility tests', async () => {
     const screen = renderTooltip({
       content: '<button>Hover me</button>',

--- a/packages/html/ds/src/tooltip/tooltip.test.ts
+++ b/packages/html/ds/src/tooltip/tooltip.test.ts
@@ -98,7 +98,9 @@ describe('govieTooltip', () => {
       position: 'top',
     });
 
-    const tooltip = screen.getByText('Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip tex...');
+    const tooltip = screen.getByText(
+      'Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip tex...',
+    );
     expect(tooltip).toBeTruthy();
   });
 

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -29,13 +29,18 @@ export class Tooltip extends BaseComponent<TooltipProps> {
 
     if (event.type === 'mouseenter') {
       tooltip.setAttribute('aria-hidden', 'false');
-    } else if (event.type === 'mouseleave' && !wrapper.contains(document.activeElement)) {
+    } else if (
+      event.type === 'mouseleave' &&
+      !wrapper.contains(document.activeElement)
+    ) {
       tooltip.setAttribute('aria-hidden', 'true');
     }
   }
 
   handleFocus(event: FocusEvent) {
-    const wrapper = (event.target as HTMLElement).closest('.gi-tooltip-wrapper');
+    const wrapper = (event.target as HTMLElement).closest(
+      '.gi-tooltip-wrapper',
+    );
     const tooltip = wrapper?.querySelector('[role="tooltip"]');
 
     if (wrapper && tooltip) {
@@ -44,9 +49,11 @@ export class Tooltip extends BaseComponent<TooltipProps> {
   }
 
   handleBlur(event: FocusEvent) {
-    const wrapper = (event.target as HTMLElement).closest('.gi-tooltip-wrapper');
+    const wrapper = (event.target as HTMLElement).closest(
+      '.gi-tooltip-wrapper',
+    );
     const tooltip = wrapper?.querySelector('[role="tooltip"]');
-    
+
     const relatedTarget = event.relatedTarget as HTMLElement;
     if (wrapper && tooltip && !wrapper.contains(relatedTarget)) {
       tooltip.setAttribute('aria-hidden', 'true');
@@ -55,58 +62,52 @@ export class Tooltip extends BaseComponent<TooltipProps> {
 
   handleKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
-      // Find all visible tooltips and hide them
-      this.getAllTooltips.forEach(wrapper => {
+      for (const wrapper of this.getAllTooltips) {
         const tooltip = wrapper.querySelector('[role="tooltip"]');
         if (tooltip && tooltip.getAttribute('aria-hidden') === 'false') {
           tooltip.setAttribute('aria-hidden', 'true');
-          
-          // If the wrapper is focused, keep the focus but hide the tooltip
+
           if (wrapper.contains(document.activeElement)) {
             (document.activeElement as HTMLElement).focus();
           }
         }
-      });
+      }
     }
   }
 
   hideAllTooltips() {
-    this.getAllTooltips.forEach(wrapper => {
+    for (const wrapper of this.getAllTooltips) {
       const tooltip = wrapper.querySelector('[role="tooltip"]');
       if (tooltip) {
         tooltip.setAttribute('aria-hidden', 'true');
       }
-    });
+    }
   }
 
   private truncateText(text: string): string {
-    return text.length > 100 
-      ? text.substring(0, 100).trim() + '...'
-      : text;
+    return text.length > 100 ? text.slice(0, 100).trim() + '...' : text;
   }
 
   initComponent() {
-    this.getAllTooltips.forEach(wrapper => {
+    for (const wrapper of this.getAllTooltips) {
       const tooltipElement = wrapper.querySelector('[role="tooltip"]');
       if (tooltipElement) {
         const originalText = tooltipElement.textContent || '';
         tooltipElement.textContent = this.truncateText(originalText);
       }
-    });
+    }
 
     for (const tooltipWrapper of this.getAllTooltips) {
-      // Mouse events
       tooltipWrapper.addEventListener(
         'mouseenter',
         this.handleTooltipVisibility,
-        false
+        false,
       );
       tooltipWrapper.addEventListener(
         'mouseleave',
         this.handleTooltipVisibility,
-        false
+        false,
       );
-
       tooltipWrapper.addEventListener('focusin', this.handleFocus, false);
       tooltipWrapper.addEventListener('focusout', this.handleBlur, false);
     }
@@ -119,12 +120,12 @@ export class Tooltip extends BaseComponent<TooltipProps> {
       tooltipWrapper.removeEventListener(
         'mouseenter',
         this.handleTooltipVisibility,
-        false
+        false,
       );
       tooltipWrapper.removeEventListener(
         'mouseleave',
         this.handleTooltipVisibility,
-        false
+        false,
       );
       tooltipWrapper.removeEventListener('focusin', this.handleFocus, false);
       tooltipWrapper.removeEventListener('focusout', this.handleBlur, false);

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -14,6 +14,9 @@ export class Tooltip extends BaseComponent<TooltipProps> {
     this.getAllTooltips = document.querySelectorAll('.gi-tooltip-wrapper');
 
     this.handleTooltipVisibility = this.handleTooltipVisibility.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   handleTooltipVisibility(event: MouseEvent) {
@@ -26,24 +29,75 @@ export class Tooltip extends BaseComponent<TooltipProps> {
 
     if (event.type === 'mouseenter') {
       tooltip.setAttribute('aria-hidden', 'false');
-    } else if (event.type === 'mouseleave') {
+    } else if (event.type === 'mouseleave' && !wrapper.contains(document.activeElement)) {
       tooltip.setAttribute('aria-hidden', 'true');
     }
   }
 
+  handleFocus(event: FocusEvent) {
+    const wrapper = (event.target as HTMLElement).closest('.gi-tooltip-wrapper');
+    const tooltip = wrapper?.querySelector('[role="tooltip"]');
+
+    if (wrapper && tooltip) {
+      tooltip.setAttribute('aria-hidden', 'false');
+    }
+  }
+
+  handleBlur(event: FocusEvent) {
+    const wrapper = (event.target as HTMLElement).closest('.gi-tooltip-wrapper');
+    const tooltip = wrapper?.querySelector('[role="tooltip"]');
+    
+    const relatedTarget = event.relatedTarget as HTMLElement;
+    if (wrapper && tooltip && !wrapper.contains(relatedTarget)) {
+      tooltip.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      // Find all visible tooltips and hide them
+      this.getAllTooltips.forEach(wrapper => {
+        const tooltip = wrapper.querySelector('[role="tooltip"]');
+        if (tooltip && tooltip.getAttribute('aria-hidden') === 'false') {
+          tooltip.setAttribute('aria-hidden', 'true');
+          
+          // If the wrapper is focused, keep the focus but hide the tooltip
+          if (wrapper.contains(document.activeElement)) {
+            (document.activeElement as HTMLElement).focus();
+          }
+        }
+      });
+    }
+  }
+
+  hideAllTooltips() {
+    this.getAllTooltips.forEach(wrapper => {
+      const tooltip = wrapper.querySelector('[role="tooltip"]');
+      if (tooltip) {
+        tooltip.setAttribute('aria-hidden', 'true');
+      }
+    });
+  }
+
   initComponent() {
     for (const tooltipWrapper of this.getAllTooltips) {
+      // Mouse events
       tooltipWrapper.addEventListener(
         'mouseenter',
         this.handleTooltipVisibility,
-        false,
+        false
       );
       tooltipWrapper.addEventListener(
         'mouseleave',
         this.handleTooltipVisibility,
-        false,
+        false
       );
+
+      tooltipWrapper.addEventListener('focusin', this.handleFocus, false);
+      tooltipWrapper.addEventListener('focusout', this.handleBlur, false);
     }
+
+    document.addEventListener('keydown', this.handleKeyDown, false);
   }
 
   destroyComponent(): void {
@@ -51,14 +105,17 @@ export class Tooltip extends BaseComponent<TooltipProps> {
       tooltipWrapper.removeEventListener(
         'mouseenter',
         this.handleTooltipVisibility,
-        false,
+        false
       );
       tooltipWrapper.removeEventListener(
         'mouseleave',
         this.handleTooltipVisibility,
-        false,
+        false
       );
+      tooltipWrapper.removeEventListener('focusin', this.handleFocus, false);
+      tooltipWrapper.removeEventListener('focusout', this.handleBlur, false);
     }
+    document.removeEventListener('keydown', this.handleKeyDown, false);
   }
 }
 

--- a/packages/html/ds/src/tooltip/tooltip.ts
+++ b/packages/html/ds/src/tooltip/tooltip.ts
@@ -79,7 +79,21 @@ export class Tooltip extends BaseComponent<TooltipProps> {
     });
   }
 
+  private truncateText(text: string): string {
+    return text.length > 100 
+      ? text.substring(0, 100).trim() + '...'
+      : text;
+  }
+
   initComponent() {
+    this.getAllTooltips.forEach(wrapper => {
+      const tooltipElement = wrapper.querySelector('[role="tooltip"]');
+      if (tooltipElement) {
+        const originalText = tooltipElement.textContent || '';
+        tooltipElement.textContent = this.truncateText(originalText);
+      }
+    });
+
     for (const tooltipWrapper of this.getAllTooltips) {
       // Mouse events
       tooltipWrapper.addEventListener(

--- a/packages/react/ds/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.stories.tsx
@@ -41,7 +41,7 @@ const meta = {
     },
   },
   decorators: (Story) => (
-    <div className="gi-flex gi-justify-center gi-py-5 gi-px-5">
+    <div className="gi-flex gi-justify-center gi-my-20 gi-mx-20">
       <Story />
     </div>
   ),
@@ -52,7 +52,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    text: 'Default Tooltip',
+    text: 'This is a tooltip at the top.',
     position: 'top',
     children: <Button variant="primary">Hover me (Top)</Button>,
   },
@@ -92,7 +92,7 @@ export const RightPosition: Story = {
 
 export const WithLongText: Story = {
   args: {
-    text: 'This is a very long tooltip text that tests the tooltip display.',
+    text: 'This is a very long tooltip text that tests the tooltip display. This is a very long tooltip text that tests the tooltip display.',
     position: 'top',
     children: <Button variant="primary">Hover me (Top)</Button>,
   },

--- a/packages/react/ds/src/tooltip/tooltip.test.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.test.tsx
@@ -98,6 +98,23 @@ describe('govieTooltip', () => {
     expect(tooltipTextElement).toBeInTheDocument();
   });
 
+  it('should render ellipis with long tooltip text', () => {
+    const tooltipText =
+      'Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip text.';
+    const screen = renderTooltip({
+      text: tooltipText,
+      position: 'top',
+      children: <button>Hover me</button>,
+    });
+
+    fireEvent.mouseEnter(screen.getByText('Hover me'));
+
+    const tooltipTextElement = screen.getByText(
+      'Very long tooltip text. Very long tooltip text. Very long tooltip text. Very long tooltip text. Very...',
+    );
+    expect(tooltipTextElement).toBeInTheDocument();
+  });
+
   it('should pass axe accessibility tests', async () => {
     const screen = renderTooltip({
       text: 'Accessibility Tooltip',

--- a/packages/react/ds/src/tooltip/tooltip.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.tsx
@@ -55,7 +55,9 @@ export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
       className="gi-tooltip-wrapper"
       onMouseEnter={showTooltip}
       onMouseLeave={() => {
-        if (!isFocused) hideTooltip();
+        if (!isFocused) {
+          hideTooltip();
+        }
       }}
       onFocus={() => {
         setIsFocused(true);
@@ -81,5 +83,3 @@ export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
     </span>
   );
 };
-
-export default Tooltip;

--- a/packages/react/ds/src/tooltip/tooltip.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.tsx
@@ -1,14 +1,13 @@
 'use client';
-import { ReactNode, useState, useId } from 'react';
+import { ReactNode, useState, useId, useEffect, useCallback } from 'react';
 import { tv } from 'tailwind-variants';
 
 export const positionVariants = ['top', 'bottom', 'left', 'right'];
-
 export type Position = 'top' | 'bottom' | 'left' | 'right';
 
 type TooltipProps = {
   text: string;
-  position: Position;
+  position?: Position;
   children: ReactNode;
 };
 
@@ -26,16 +25,46 @@ const tooltipTv = tv({
 
 export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
   const [isVisible, setIsVisible] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const describedById = useId();
 
   const showTooltip = () => setIsVisible(true);
-  const hideTooltip = () => setIsVisible(false);
+  const hideTooltip = useCallback(() => {
+    setIsVisible(false);
+    setIsFocused(false);
+  }, []);
+
+  const handleEscapeKey = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        hideTooltip();
+      }
+    },
+    [hideTooltip],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscapeKey);
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [handleEscapeKey]);
 
   return (
     <span
       className="gi-tooltip-wrapper"
       onMouseEnter={showTooltip}
-      onMouseLeave={hideTooltip}
+      onMouseLeave={() => {
+        if (!isFocused) hideTooltip();
+      }}
+      onFocus={() => {
+        setIsFocused(true);
+        showTooltip();
+      }}
+      onBlur={() => {
+        hideTooltip();
+      }}
+      role="button"
       aria-describedby={isVisible ? describedById : undefined}
     >
       {children}
@@ -44,7 +73,7 @@ export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
           id={describedById}
           role="tooltip"
           className={tooltipTv({ position })}
-          aria-hidden="false"
+          aria-hidden={!isVisible}
         >
           {text}
         </span>
@@ -52,3 +81,5 @@ export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
     </span>
   );
 };
+
+export default Tooltip;

--- a/packages/react/ds/src/tooltip/tooltip.tsx
+++ b/packages/react/ds/src/tooltip/tooltip.tsx
@@ -75,7 +75,7 @@ export const Tooltip = ({ text, position = 'top', children }: TooltipProps) => {
           className={tooltipTv({ position })}
           aria-hidden={!isVisible}
         >
-          {text}
+          {text.length > 100 ? text.slice(0, 100) + '...' : text}
         </span>
       )}
     </span>


### PR DESCRIPTION
Tooltip updated with:

- Visibility on focus.
- Hide on escape key.
- Max characters to 100.
- Max width to 300px.

![Screenshot 2025-02-04 at 15 54 36](https://github.com/user-attachments/assets/acbbc305-845c-44b6-8b42-daf8bc39a893)
