### PR TITLE
chore: update data test id for button

### DIFF
--- a/packages/html/ds/src/button/button-schema.ts
+++ b/packages/html/ds/src/button/button-schema.ts
@@ -78,7 +78,7 @@ export const buttonSchema = zod.object({
       description: 'The value for the button sent in the request',
     })
     .optional(),
-  dataTestid: zod.string({ description: 'Data test id for button'}).optional(),
+  dataTestid: zod.string({ description: 'Data test id for button' }).optional(),
   aria: ariaSchema.describe('Defines the aria attributes').optional(),
 });
 

--- a/packages/html/ds/src/button/button-schema.ts
+++ b/packages/html/ds/src/button/button-schema.ts
@@ -78,6 +78,7 @@ export const buttonSchema = zod.object({
       description: 'The value for the button sent in the request',
     })
     .optional(),
+  dataTestid: zod.string({ description: 'Data test id for button'}).optional(),
   aria: ariaSchema.describe('Defines the aria attributes').optional(),
 });
 

--- a/packages/html/ds/src/button/button.html
+++ b/packages/html/ds/src/button/button.html
@@ -6,7 +6,7 @@
   {% set variant = props.variant or 'primary' %}
   {% set size = props.size or 'medium' %}
   {% set isDisabled = 'disabled' if props.disabled else 'notDisabled' %}
-  {% set testId = props.testId or 'govieButton-' ~ appearance ~ '-' ~ variant ~ '-' ~ size ~ '-' ~ isDisabled %}
+  {% set testId = props.dataTestid or 'govieButton-' ~ appearance ~ '-' ~ variant ~ '-' ~ size ~ '-' ~ isDisabled %}
   {% set commonClasses = getVariantAppearanceClass(props.disabled, props.variant, props.appearance) | trim %}
   {% set sizeClasses = getSizeClass(props.size) | trim %}
   {% set disabledClasses = isButtonDisabled(props.disabled, props.variant, props.appearance) | trim %}

--- a/packages/html/ds/src/button/button.test.ts
+++ b/packages/html/ds/src/button/button.test.ts
@@ -13,7 +13,7 @@ import html from './button.html?raw';
 const standardProps = {
   content: 'Button Label',
   variant: ButtonVariant.Primary,
-  dataTestid: 'govie-button'
+  dataTestid: 'govie-button',
 };
 
 describe('button', () => {
@@ -62,7 +62,7 @@ describe('button', () => {
       variant: ButtonVariant.Flat,
     };
     const screen = renderButton(propsFlatButton);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -72,7 +72,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Default,
     };
     const screen = renderButton(propsDefaultAppearance);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -82,7 +82,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Light,
     };
     const screen = renderButton(propsLightAppearance);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -92,7 +92,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Dark,
     };
     const screen = renderButton(propsDarkAppearance);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -102,7 +102,7 @@ describe('button', () => {
       size: ButtonSize.Small,
     };
     const screen = renderButton(propsSmallButton);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -112,7 +112,7 @@ describe('button', () => {
       size: ButtonSize.Large,
     };
     const screen = renderButton(propsLargeButton);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -122,7 +122,7 @@ describe('button', () => {
       disabled: true,
     };
     const screen = renderButton(propsDisabledButton);
-    const buttonElement = screen.getByTestId('govie-button');;
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 

--- a/packages/html/ds/src/button/button.test.ts
+++ b/packages/html/ds/src/button/button.test.ts
@@ -13,6 +13,7 @@ import html from './button.html?raw';
 const standardProps = {
   content: 'Button Label',
   variant: ButtonVariant.Primary,
+  dataTestid: 'govie-button'
 };
 
 describe('button', () => {
@@ -41,7 +42,7 @@ describe('button', () => {
 
   it('should render a primary button', () => {
     const screen = renderButton(standardProps);
-    const buttonElement = screen.getByTestId('primary', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -51,7 +52,7 @@ describe('button', () => {
       variant: ButtonVariant.Secondary,
     };
     const screen = renderButton(propsSecondaryButton);
-    const buttonElement = screen.getByTestId('secondary', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -61,7 +62,7 @@ describe('button', () => {
       variant: ButtonVariant.Flat,
     };
     const screen = renderButton(propsFlatButton);
-    const buttonElement = screen.getByTestId('flat', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -71,7 +72,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Default,
     };
     const screen = renderButton(propsDefaultAppearance);
-    const buttonElement = screen.getByTestId('default', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -81,7 +82,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Light,
     };
     const screen = renderButton(propsLightAppearance);
-    const buttonElement = screen.getByTestId('light', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -91,7 +92,7 @@ describe('button', () => {
       appearance: ButtonAppearance.Dark,
     };
     const screen = renderButton(propsDarkAppearance);
-    const buttonElement = screen.getByTestId('dark', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -101,7 +102,7 @@ describe('button', () => {
       size: ButtonSize.Small,
     };
     const screen = renderButton(propsSmallButton);
-    const buttonElement = screen.getByTestId('small', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -111,7 +112,7 @@ describe('button', () => {
       size: ButtonSize.Large,
     };
     const screen = renderButton(propsLargeButton);
-    const buttonElement = screen.getByTestId('large', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 
@@ -121,7 +122,7 @@ describe('button', () => {
       disabled: true,
     };
     const screen = renderButton(propsDisabledButton);
-    const buttonElement = screen.getByTestId('disabled', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');;
     expect(buttonElement).toBeTruthy();
   });
 

--- a/packages/html/ds/src/pagination/pagination.html
+++ b/packages/html/ds/src/pagination/pagination.html
@@ -18,7 +18,7 @@
         "disabled": props.currentPage == 1,
         "href": "#",
         "target": "_self",
-        "testId": "govie-pagination-prev-btn",
+        "dataTestid": "govie-pagination-prev-btn",
         "data-current-page": props.currentPage - 1,
         "className": "gi-pagination-prev-btn",
         "aria": {
@@ -46,7 +46,7 @@
         "href": "#",
         "target": "_self",
         "disabled": props.currentPage == props.totalPages,
-        "testId": "govie-pagination-next-btn",
+        "dataTestid": "govie-pagination-next-btn",
         "data-current-page": props.currentPage + 1,
         "className": "gi-pagination-next-btn",
         "aria": {

--- a/packages/react/ds/src/button/button.test.tsx
+++ b/packages/react/ds/src/button/button.test.tsx
@@ -6,6 +6,7 @@ import { ButtonProps, ButtonVariant, ButtonVariants } from './types.js';
 const standardProps: ButtonProps = {
   children: 'Button Label',
   variant: 'primary',
+  dataTestid: 'govie-button',
 };
 
 describe('button', () => {
@@ -20,9 +21,7 @@ describe('button', () => {
   it('should render the label', () => {
     const screen = renderButton(standardProps);
     const buttonElement = screen.getByText(standardProps.children as string);
-    const primaryButtonElement = screen.getByTestId('primary', {
-      exact: false,
-    });
+    const primaryButtonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
     expect(primaryButtonElement).toBeTruthy();
   });
@@ -33,7 +32,7 @@ describe('button', () => {
       variant: 'secondary',
     };
     const screen = renderButton(propsSecondaryButton);
-    const buttonElement = screen.getByTestId('secondary', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -43,7 +42,7 @@ describe('button', () => {
       variant: 'flat',
     };
     const screen = renderButton(propsFlatButton);
-    const buttonElement = screen.getByTestId('flat', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -53,7 +52,7 @@ describe('button', () => {
       appearance: 'default',
     };
     const screen = renderButton(propsDefaultAppearance);
-    const buttonElement = screen.getByTestId('default', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -63,7 +62,7 @@ describe('button', () => {
       appearance: 'light',
     };
     const screen = renderButton(propsLightAppearance);
-    const buttonElement = screen.getByTestId('light', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -73,7 +72,7 @@ describe('button', () => {
       appearance: 'dark',
     };
     const screen = renderButton(propsDarkAppearance);
-    const buttonElement = screen.getByTestId('dark', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -83,7 +82,7 @@ describe('button', () => {
       size: 'small',
     };
     const screen = renderButton(propsSmallButton);
-    const buttonElement = screen.getByTestId('small', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -93,7 +92,7 @@ describe('button', () => {
       size: 'large',
     };
     const screen = renderButton(propsLargeButton);
-    const buttonElement = screen.getByTestId('large', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
     expect(buttonElement).toBeTruthy();
   });
 
@@ -103,7 +102,7 @@ describe('button', () => {
       disabled: true,
     };
     const screen = renderButton(propsDisabledButton);
-    const buttonElement = screen.getByTestId('disabled', { exact: false });
+    const buttonElement = screen.getByTestId('govie-button');
 
     expect(buttonElement).toBeTruthy();
     expect(buttonElement).toBeDisabled();

--- a/packages/react/ds/src/button/button.tsx
+++ b/packages/react/ds/src/button/button.tsx
@@ -16,7 +16,16 @@ export type ExtendedButtonProps =
 
 export const Button = React.forwardRef<HTMLButtonElement, ExtendedButtonProps>(
   (
-    { variant, appearance, size, disabled, className, children, ...props },
+    {
+      variant,
+      appearance,
+      size,
+      disabled,
+      className,
+      dataTestid,
+      children,
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -24,7 +33,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ExtendedButtonProps>(
         {...props}
         ref={ref}
         disabled={disabled}
-        data-testid={`govieButton-${appearance}-${variant}-${size}-${disabled ? 'disabled' : ''}`}
+        data-testid={dataTestid}
         className={cn(
           'gi-btn',
           getVariantAppearanceClass({ disabled, variant, appearance }),

--- a/packages/react/ds/src/button/types.ts
+++ b/packages/react/ds/src/button/types.ts
@@ -21,4 +21,5 @@ export type ButtonProps = {
   ariaLabel?: string;
   ariaDescribedBy?: string;
   ariaPressed?: boolean;
+  dataTestid?: string;
 };


### PR DESCRIPTION
Previously I didn't touched button since it could've caused regression. Now exposing button data test id separately.