### PR TITLE
fix: update tab list checked state

### DIFF
--- a/packages/react/ds/src/tabs/tab-list.tsx
+++ b/packages/react/ds/src/tabs/tab-list.tsx
@@ -30,7 +30,7 @@ export const TabList = ({
     });
 
     setActiveTab(foundCheckedTab ? checkedIndex : 0);
-  }, [children, tabName]);
+  }, []);
 
   const onTabSelected = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,

--- a/packages/react/ds/src/tabs/tab-list.tsx
+++ b/packages/react/ds/src/tabs/tab-list.tsx
@@ -1,5 +1,6 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { TabItemProps } from './tab-item.js';
 
 export const TabList = ({
   children,
@@ -8,8 +9,28 @@ export const TabList = ({
   tabName?: string;
   children: React.ReactNode;
 }) => {
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTab, setActiveTab] = useState<number | null>(null);
   const tabCount = React.Children.count(children);
+
+  useEffect(() => {
+    // Initialize the active tab based on children
+    // Find if any child is checked
+    let foundCheckedTab = false;
+    let checkedIndex = 0;
+
+    React.Children.forEach(children, (child, index) => {
+      if (
+        React.isValidElement<TabItemProps>(child) &&
+        'checked' in child.props &&
+        child.props.checked === true
+      ) {
+        checkedIndex = index;
+        foundCheckedTab = true;
+      }
+    });
+
+    setActiveTab(foundCheckedTab ? checkedIndex : 0);
+  }, [children, tabName]);
 
   const onTabSelected = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -41,7 +62,7 @@ export const TabList = ({
 
     switch (event.key) {
       case 'ArrowLeft': {
-        let newTab = activeTab - 1;
+        let newTab = (activeTab ?? 0) - 1;
         if (newTab < 0) {
           newTab = 0;
         }
@@ -51,7 +72,7 @@ export const TabList = ({
       }
 
       case 'ArrowRight': {
-        let newTab = activeTab + 1;
+        let newTab = (activeTab ?? 0) + 1;
         if (newTab >= tabCount) {
           newTab = tabCount - 1;
         }
@@ -105,6 +126,7 @@ export const TabList = ({
     }
     return element;
   });
+
   return (
     <div role="tablist" className="gi--mb-[1px]">
       {childrenWithName}

--- a/packages/react/ds/src/tabs/tabs.stories.tsx
+++ b/packages/react/ds/src/tabs/tabs.stories.tsx
@@ -29,9 +29,7 @@ export const Default: Story = {
     return (
       <Tabs {...arguments_}>
         <TabList>
-          <TabItem value="tab1" checked>
-            Tab 1
-          </TabItem>
+          <TabItem value="tab1">Tab 1</TabItem>
           <TabItem value="tab2">Tab 2</TabItem>
           <TabItem value="tab3">Tab 3</TabItem>
         </TabList>
@@ -70,5 +68,29 @@ export const AllStates: Story = {
       hover: '#tab-tab21',
       focus: '#tab-tab31',
     },
+  },
+};
+
+export const CheckedTab: Story = {
+  args: {
+    id: 'tab-story',
+    children: '',
+    ariaLabelledBy: 'tab-story',
+  },
+  render: (arguments_) => {
+    return (
+      <Tabs {...arguments_}>
+        <TabList>
+          <TabItem value="tab1">Tab 1</TabItem>
+          <TabItem value="tab2" checked>
+            Tab 2
+          </TabItem>
+          <TabItem value="tab3">Tab 3</TabItem>
+        </TabList>
+        <TabPanel value="tab1">Tab 1 Content</TabPanel>
+        <TabPanel value="tab2">Tab 2 Content (checked)</TabPanel>
+        <TabPanel value="tab3">Tab 3 Content</TabPanel>
+      </Tabs>
+    );
   },
 };

--- a/packages/react/ds/src/tabs/tabs.test.tsx
+++ b/packages/react/ds/src/tabs/tabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, cleanup } from '../test-utils.js';
+import { render, cleanup, fireEvent } from '../test-utils.js';
 import { TabsContent } from './tabs-content.js';
 import { TabsProps, Tabs } from './tabs.js';
 
@@ -22,6 +22,22 @@ describe('tabs', () => {
       children: TabsContent,
     });
     expect(screen.getByText('Tab 2 Content')).toBeTruthy();
+  });
+
+  it('should allow selecting a tab', () => {
+    const screen = renderTabs({
+      ariaLabelledBy: 'tabs',
+      id: 'tab-1',
+      children: TabsContent,
+    });
+
+    const tabButtons = screen.getAllByRole('tab');
+
+    fireEvent.click(tabButtons[1]);
+
+    expect(tabButtons[1]).toHaveAttribute('aria-selected', 'true');
+    expect(tabButtons[0]).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('Tab 2 Content')).toBeVisible();
   });
 
   it('should pass axe tests', async () => {

--- a/packages/react/ds/src/tabs/tabs.test.tsx
+++ b/packages/react/ds/src/tabs/tabs.test.tsx
@@ -31,13 +31,16 @@ describe('tabs', () => {
       children: TabsContent,
     });
 
-    const tabButtons = screen.getAllByRole('tab');
+    const tablist = screen.container.querySelector('[role="tablist"]');
+    const tabButtons = tablist?.querySelectorAll('button');
 
-    fireEvent.click(tabButtons[1]);
+    if (tabButtons) {
+      fireEvent.click(tabButtons[1]);
 
-    expect(tabButtons[1]).toHaveAttribute('aria-selected', 'true');
-    expect(tabButtons[0]).toHaveAttribute('aria-selected', 'false');
-    expect(screen.getByText('Tab 2 Content')).toBeVisible();
+      expect(tabButtons[1]).toHaveAttribute('aria-selected', 'true');
+      expect(tabButtons[0]).toHaveAttribute('aria-selected', 'false');
+      expect(screen.getByText('Tab 2 Content')).toBeVisible();
+    }
   });
 
   it('should pass axe tests', async () => {


### PR DESCRIPTION
- Update initial set active tab if any children got `checked` true.
- If no `checked` state is defined then set `0` index tab item to be visible.
- Added associated story for that.
- Added associated unit test.

Testing Screenshot:
![Screenshot 2025-03-06 at 03 58 01](https://github.com/user-attachments/assets/fadd1924-7a9c-46f0-9669-5abd98516e8f)
