### PR TITLE
docs: update progress stepper documentation formatting

### DIFF
--- a/apps/docs/content/3-components/2-library/progress-stepper.mdx
+++ b/apps/docs/content/3-components/2-library/progress-stepper.mdx
@@ -32,73 +32,71 @@ libraries:
 
 <Tabs id="tab1">
   <TabList>
-    <TabItem value="tab11" checked>
-      HTML
-    </TabItem>
+    <TabItem value="tab11" checked>HTML</TabItem>
     <TabItem value="tab12">React</TabItem>
   </TabList>
   <TabPanel value="tab11">
     ```html
     <div data-testid="progress-stepper" class="gi-progress-stepper" data-orientation="horizontal" role="list" aria-live="polite">
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="true" data-next="false" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-1">
-            <div class="gi-progress-stepper-step"><span data-testid="govie-icon" role="presentation" class="gi-block material-symbols-outlined" style="font-size: 24px;">check</span></div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-1">Start Your Application</div>
-         </div>
-         <div data-orientation="horizontal" data-next="false" data-completed="true" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="true" data-next="false" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-1">
+                <div class="gi-progress-stepper-step"><span data-testid="govie-icon" role="presentation" class="gi-block material-symbols-outlined" style="font-size: 24px;">check</span></div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-1">Start Your Application</div>
+            </div>
+            <div data-orientation="horizontal" data-next="false" data-completed="true" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+          </div>
       </div>
-   </div>
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="true" data-completed="false" data-next="false" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-2">
-            <div class="gi-progress-stepper-step">#</div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-2">Personal Information</div>
-         </div>
-         <div data-orientation="horizontal" data-next="false" data-completed="false" data-current="true" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span><span></span></div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="true" data-completed="false" data-next="false" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-2">
+                <div class="gi-progress-stepper-step">#</div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-2">Personal Information</div>
+            </div>
+            <div data-orientation="horizontal" data-next="false" data-completed="false" data-current="true" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span><span></span></div>
+          </div>
       </div>
-   </div>
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-3">
-            <div class="gi-progress-stepper-step">#</div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-3">Eligibility Check</div>
-         </div>
-         <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-3">
+                <div class="gi-progress-stepper-step">#</div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-3">Eligibility Check</div>
+            </div>
+            <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+          </div>
       </div>
-   </div>
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-4">
-            <div class="gi-progress-stepper-step">#</div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-4">Documents Submission</div>
-         </div>
-         <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-4">
+                <div class="gi-progress-stepper-step">#</div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-4">Documents Submission</div>
+            </div>
+            <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+          </div>
       </div>
-   </div>
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-5">
-            <div class="gi-progress-stepper-step">#</div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-5">Review</div>
-         </div>
-         <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-5">
+                <div class="gi-progress-stepper-step">#</div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-5">Review</div>
+            </div>
+            <div data-orientation="horizontal" data-next="true" data-completed="false" data-current="false" class="gi-progress-stepper-step-connector" aria-hidden="true"><span></span></div>
+          </div>
       </div>
-   </div>
-   <div class="gi-w-full">
-      <div class="gi-relative">
-         <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-6">
-            <div class="gi-progress-stepper-step">#</div>
-            <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-6">Complete &amp; Submit</div>
-         </div>
+      <div class="gi-w-full">
+          <div class="gi-relative">
+            <div class="gi-progress-stepper-step-container" data-orientation="horizontal" data-current="false" data-completed="false" data-next="true" data-indicator="hashtag" role="listitem" aria-labelledby="step-label-6">
+                <div class="gi-progress-stepper-step">#</div>
+                <div class="gi-progress-stepper-step-label" data-orientation="horizontal" id="step-label-6">Complete &amp; Submit</div>
+            </div>
+          </div>
       </div>
-   </div>
-</div>
+    </div>
     ```
   </TabPanel>
   <TabPanel value="tab12">
     ```react 
-    import {ProgressStepper, StepItem} from '@govie-ds/react';
+    import { ProgressStepper, StepItem } from '@govie-ds/react';
 
     <ProgressStepper currentStepIndex={3}>
       <StepItem label="Step 1" />
@@ -126,9 +124,7 @@ libraries:
 
 <Tabs id="tab2">
   <TabList>
-    <TabItem value="tab21" checked>
-      HTML
-    </TabItem>
+    <TabItem value="tab21" checked>HTML</TabItem>
     <TabItem value="tab22">React</TabItem>
   </TabList>
   <TabPanel value="tab21">
@@ -200,7 +196,7 @@ libraries:
   </TabPanel>
   <TabPanel value="tab22">
     ```react 
-    import {ProgressStepper, StepItem} from '@govie-ds/react';
+    import { ProgressStepper, StepItem } from '@govie-ds/react';
 
     <ProgressStepper currentStepIndex={3}>
        <StepItem label="Step 1">Here is the Step 1</StepItem>
@@ -228,9 +224,7 @@ libraries:
 
 <Tabs id="tab3">
   <TabList>
-    <TabItem value="tab31" checked>
-      HTML
-    </TabItem>
+    <TabItem value="tab31" checked>HTML</TabItem>
     <TabItem value="tab32">React</TabItem>
   </TabList>
   <TabPanel value="tab31">
@@ -285,7 +279,7 @@ libraries:
   </TabPanel>
   <TabPanel value="tab32">
     ```react 
-    import {ProgressStepper, StepItem} from '@govie-ds/react';
+    import { ProgressStepper, StepItem } from '@govie-ds/react';
 
     <ProgressStepper currentStepIndex={3} orientation="vertical">
       <StepItem label="Step 1" />
@@ -326,9 +320,7 @@ libraries:
 
 <Tabs id="tab4">
   <TabList>
-    <TabItem value="tab41" checked>
-      HTML
-    </TabItem>
+    <TabItem value="tab41" checked>HTML</TabItem>
     <TabItem value="tab42">React</TabItem>
   </TabList>
   <TabPanel value="tab41">
@@ -410,7 +402,7 @@ libraries:
   </TabPanel>
   <TabPanel value="tab42">
     ```react 
-    import {ProgressStepper, StepItem} from '@govie-ds/react';
+    import { ProgressStepper, StepItem } from '@govie-ds/react';
 
     <ProgressStepper currentStepIndex={2} orientation="vertical">
       <StepItem label="Start Your Application" defaultOpen>


### PR DESCRIPTION
## Description

- Broken tabs now fixed for progress stepper documentation.
- Minor associated formatting.

![Screenshot 2025-03-14 at 09 31 36](https://github.com/user-attachments/assets/e6ba76c3-52cc-4e68-8df4-4c0ea74c1b9a)

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [X] 🔧 Chore

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.