### PR TITLE
fix: icon button sizes

### DIFF
--- a/packages/html/ds/src/helpers/buttons.tsx
+++ b/packages/html/ds/src/helpers/buttons.tsx
@@ -112,7 +112,7 @@ export const createIconButton = (arguments_: IconButtonProps) => {
   component.className =
     `gi-btn ${classSize} ${classAppearance} ${arguments_.className || ''}`.trim();
 
-  const iconSize = arguments_.size === 'large' ? 'md' : 'sm';
+  const iconSize = arguments_.size === 'small' ? 'sm' : 'md';
   const icon = createIcon({ ...arguments_.icon, size: iconSize });
   component.append(icon);
 

--- a/packages/react/ds/src/icon-button/icon-button.test.tsx
+++ b/packages/react/ds/src/icon-button/icon-button.test.tsx
@@ -79,7 +79,7 @@ describe('icon-button', () => {
       exact: false,
     });
 
-    expect(iconElement).toHaveStyle('font-size: 16px');
+    expect(iconElement).toHaveStyle('font-size: 24px');
     expect(buttonElement.classList.contains(buttonClass)).toBeTruthy();
   });
 

--- a/packages/react/ds/src/icon-button/icon-button.tsx
+++ b/packages/react/ds/src/icon-button/icon-button.tsx
@@ -32,7 +32,7 @@ export const IconButton = ({
   onClick,
   className = '',
 }: IconButtonProps) => {
-  const iconSize = size === 'large' ? 'md' : 'sm';
+  const iconSize = size === 'small' ? 'sm' : 'md';
   return (
     <button
       aria-disabled={disabled}


### PR DESCRIPTION
## Description

Icon button with medium size was showing small icon

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

<!-- List any related issues or pull requests (e.g., "Fixes #123"). -->

## Additional Notes

<!-- Add any additional context or information that may be useful for reviewers. For example, known issues, potential impacts, or anything else relevant. -->
