### PR TITLE
fix: add vertical align prop on table data and header

### DIFF
--- a/packages/design/tailwind/css/components/table.css
+++ b/packages/design/tailwind/css/components/table.css
@@ -4,7 +4,7 @@
 
 .gi-table-th,
 .gi-table-td {
-  @apply gi-align-middle gi-pl-1 gi-pr-5 gi-py-2.5 gi-border-b-[gray] gi-border-b gi-border-solid;
+  @apply gi-pl-1 gi-pr-5 gi-py-2.5 gi-border-b-[gray] gi-border-b gi-border-solid;
 }
 
 .gi-table-caption-text {

--- a/packages/html/ds/src/table/table.stories.ts
+++ b/packages/html/ds/src/table/table.stories.ts
@@ -71,6 +71,7 @@ const createTable = (arguments_: TablePropsExtension) => {
 };
 
 const createElement = (arguments_: TablePropsExtension) => {
+  console.log(arguments_);
   const component = createTable(arguments_);
   return beautifyHtmlNode(component);
 };

--- a/packages/react/ds/src/table/table-data.tsx
+++ b/packages/react/ds/src/table/table-data.tsx
@@ -1,13 +1,15 @@
 import { TdHTMLAttributes } from 'react';
 import { cn } from '../cn.js';
-import { TableAlign } from './table.js';
+import { TableAlign, VerticalAlign } from './table.js';
 
 interface TableDataProps extends TdHTMLAttributes<HTMLTableCellElement> {
   align?: TableAlign;
+  valign?: VerticalAlign;
 }
 
 export function TableData({
   align = 'left',
+  valign = 'middle',
   className,
   children,
   ...props
@@ -18,8 +20,22 @@ export function TableData({
     right: 'gi-text-right',
   }[align];
 
+  const verticalAlignmentClass = {
+    top: 'gi-align-top',
+    middle: 'gi-align-middle',
+    bottom: 'gi-align-bottom',
+  }[valign];
+
   return (
-    <td className={cn('gi-table-td', alignmentClass, className)} {...props}>
+    <td
+      className={cn(
+        alignmentClass,
+        verticalAlignmentClass,
+        'gi-table-td',
+        className,
+      )}
+      {...props}
+    >
       {children}
     </td>
   );

--- a/packages/react/ds/src/table/table-header.tsx
+++ b/packages/react/ds/src/table/table-header.tsx
@@ -1,13 +1,15 @@
 import { ThHTMLAttributes } from 'react';
 import { cn } from '../cn.js';
-import { TableAlign } from './table.js';
+import { TableAlign, VerticalAlign } from './table.js';
 
 interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   align?: TableAlign;
+  valign?: VerticalAlign;
 }
 
 export function TableHeader({
   align = 'left',
+  valign = 'middle',
   className,
   children,
   ...props
@@ -18,8 +20,22 @@ export function TableHeader({
     right: 'gi-text-right',
   }[align];
 
+  const verticalAlignmentClass = {
+    top: 'gi-align-top',
+    middle: 'gi-align-middle',
+    bottom: 'gi-align-bottom',
+  }[valign];
+
   return (
-    <th className={cn('gi-table-th', alignmentClass, className)} {...props}>
+    <th
+      className={cn(
+        alignmentClass,
+        verticalAlignmentClass,
+        'gi-table-th',
+        className,
+      )}
+      {...props}
+    >
       {children}
     </th>
   );

--- a/packages/react/ds/src/table/table.stories.tsx
+++ b/packages/react/ds/src/table/table.stories.tsx
@@ -16,7 +16,7 @@ import { TableRow } from './table-row.js';
 import { Table } from './table.js';
 
 interface TableRowData {
-  [key: string]: string;
+  [key: string]: any;
 }
 
 interface TableStoryProps extends ComponentProps<typeof Table> {

--- a/packages/react/ds/src/table/table.tsx
+++ b/packages/react/ds/src/table/table.tsx
@@ -3,6 +3,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { cn } from '../cn.js';
 
 export type TableAlign = 'left' | 'center' | 'right';
+export type VerticalAlign = 'top' | 'middle' | 'bottom';
 
 const tableVariants = tv({
   base: 'gi-table',


### PR DESCRIPTION
## Description
Add vertical align (`valign`) property on table header and data.

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [X] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.