### PR TITLE
docs: update footer with stack

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import AnalyticsProvider from '@/components/analytics-provider';
 import { GovieLink } from '@/components/navigation/custom-link';
-import { Footer, Header, HeaderProps } from '@govie-ds/react';
+import { Footer, Header, HeaderProps, Link, Stack } from '@govie-ds/react';
 import '@govie-ds/react/styles.css';
 import '@govie-ds/theme-govie/theme.css';
 import type { Metadata } from 'next';
@@ -105,7 +105,11 @@ export default function RootLayout({
             {children}
             <Footer
               secondarySlot={
-                <div className="gi-flex gi-flex-row gi-gap-y-2 gi-gap-4">
+                <Stack
+                  direction={{ base: 'column', md: 'row', xs: 'column' }}
+                  gap={4}
+                  wrap
+                >
                   {footerLinks.map((link, index) => (
                     <GovieLink
                       noColor
@@ -116,15 +120,19 @@ export default function RootLayout({
                       {link.label}
                     </GovieLink>
                   ))}
-                </div>
+                </Stack>
               }
               utilitySlot={
-                <div className="gi-flex gi-flex-row gi-gap-4 gi-justify-center gi-flex-wrap">
+                <Stack
+                  direction={{ base: 'column', md: 'row', xs: 'column' }}
+                  gap={4}
+                  itemsDistribution="center"
+                >
                   <div className="gi-text-sm">
                     © {new Date().getFullYear()} Design System of Government of
                     Ireland.
                   </div>
-                </div>
+                </Stack>
               }
             />
           </AnalyticsProvider>


### PR DESCRIPTION
## Description
Usage of stack on layout for docs footer.

![Screenshot 2025-04-24 at 12 22 45](https://github.com/user-attachments/assets/5bd78f52-90a8-494e-8537-2592c6d0bec7)
![Screenshot 2025-04-24 at 12 22 51](https://github.com/user-attachments/assets/76f8a7ea-b07c-4a72-a972-0cddda5e12b1)

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.