### PR TITLE
fix: optional clearButtonEnabled on TextArea component

### DIFF
--- a/packages/design/tailwind/css/components/text-area.css
+++ b/packages/design/tailwind/css/components/text-area.css
@@ -1,5 +1,9 @@
 .gi-textarea {
-  @apply gi-w-full gi-rounded-sm gi-focus-state-outline focus:gi-shadow-[inset_0_0_0_1px] focus:gi-border-gray-950 gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-py-1 gi-pl-2 gi-pr-10  xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10 gi-border-gray-950 gi-input-disabled-state;
+  @apply gi-w-full gi-rounded-sm gi-focus-state-outline focus:gi-shadow-[inset_0_0_0_1px] focus:gi-border-gray-950 gi-flex-initial gi-border-sm gi-border-solid gi-box-border gi-py-1 gi-pl-2 gi-pr-2  xs:gi-text-md gi-text-sm gi-resize-y gi-min-h-10 gi-border-gray-950 gi-input-disabled-state;
+}
+
+.gi-textarea[data-clear-enabled='true'] {
+  @apply gi-pr-10;
 }
 
 .gi-textarea[data-icon-start='true'] {

--- a/packages/react/ds/src/textarea/textarea.stories.tsx
+++ b/packages/react/ds/src/textarea/textarea.stories.tsx
@@ -97,6 +97,24 @@ export const Default: Story = {
   },
 };
 
+export const WithTextInputReset: Story = {
+  args: {
+    id: 'text-area-id01',
+  },
+  render: () => {
+    return (
+      <FormField
+        label={{
+          text: 'Input Label',
+          htmlFor: 'text-area-id01',
+        }}
+      >
+        <TextArea clearButtonEnabled placeholder="Placeholder" />
+      </FormField>
+    );
+  },
+};
+
 export const ResponsiveWidthWithInputText: Story = {
   args: {
     rows: 4,

--- a/packages/react/ds/src/textarea/textarea.tsx
+++ b/packages/react/ds/src/textarea/textarea.tsx
@@ -24,6 +24,7 @@ export type TextAreaProps = React.DetailedHTMLProps<
   maxChars?: number;
   halfFluid?: boolean;
   iconStart?: IconId;
+  clearButtonEnabled?: boolean;
 };
 
 export const TextArea = forwardRef(
@@ -36,6 +37,7 @@ export const TextArea = forwardRef(
       halfFluid = false,
       iconStart,
       className,
+      clearButtonEnabled,
       ...props
     }: TextAreaProps,
     externalRef,
@@ -97,22 +99,25 @@ export const TextArea = forwardRef(
               className={cn(className, 'gi-textarea')}
               ref={inputRef}
               data-icon-start={!!iconStart}
+              data-clear-enabled={clearButtonEnabled}
               maxLength={maxChars}
               onChange={handleOnChange}
               {...props}
             />
-            <div className="gi-text-area-end-element">
-              <IconButton
-                disabled={props.disabled}
-                icon={{
-                  icon: 'close',
-                }}
-                onClick={handleOnResetClick}
-                variant="flat"
-                size="small"
-                appearance="dark"
-              />
-            </div>
+            {clearButtonEnabled ? (
+              <div className="gi-text-area-end-element">
+                <IconButton
+                  disabled={props.disabled}
+                  icon={{
+                    icon: 'close',
+                  }}
+                  onClick={handleOnResetClick}
+                  variant="flat"
+                  size="small"
+                  appearance="dark"
+                />
+              </div>
+            ) : null}
           </div>
         </div>
 


### PR DESCRIPTION
## Description

 Adding clearButtonEnabled on TextArea component

## Type of Issue

- [x] 🚀 Feature
- [ ] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [x] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues


![Screenshot 2025-04-30 at 09 45 19](https://github.com/user-attachments/assets/0f2184a2-e30b-4c4d-bb55-cd7bbaca12e9)

![Screenshot 2025-04-30 at 09 45 29](https://github.com/user-attachments/assets/97ad83b7-b3d0-431f-8f16-d59c382f79c5)


