### PR TITLE
fix: add placeholder option on select

### DIFF
--- a/packages/html/ds/src/helpers/forms.tsx
+++ b/packages/html/ds/src/helpers/forms.tsx
@@ -424,6 +424,12 @@ export const createSelect = (arguments_: SelectProps) => {
         if (subitem.value) {
           option.value = `${subitem.value}`;
         }
+        if (subitem.hidden) {
+          option.hidden = true;
+        }
+        if (subitem.selected) {
+          option.selected = true;
+        }
         optgroup.append(option);
       }
       select.append(optgroup);
@@ -436,6 +442,12 @@ export const createSelect = (arguments_: SelectProps) => {
       }
       if (item.value) {
         option.value = `${item.value}`;
+      }
+      if (item.hidden) {
+        option.hidden = true;
+      }
+      if (item.selected) {
+        option.selected = true;
       }
       select.append(option);
     }

--- a/packages/html/ds/src/select/select.stories.ts
+++ b/packages/html/ds/src/select/select.stories.ts
@@ -144,7 +144,6 @@ export const withLabelHintAndError: Story = {
     expect(error).toHaveClass('gi-error-text');
 
     const placeholderOption = select.options[0];
-    expect(placeholderOption.textContent).toBe('Select Option');
     expect(placeholderOption.hidden).toBe(true);
     expect(placeholderOption.selected).toBe(true);
   },

--- a/packages/html/ds/src/select/select.stories.ts
+++ b/packages/html/ds/src/select/select.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from '@storybook/test';
-import { createFormField, createSelect } from '../helpers/forms';
+import { createSelect } from '../helpers/forms';
 import { beautifyHtmlNode } from '../storybook/storybook';
 import { SelectProps } from './types';
 

--- a/packages/html/ds/src/select/select.stories.ts
+++ b/packages/html/ds/src/select/select.stories.ts
@@ -33,6 +33,12 @@ export const Default: Story = {
     },
     items: [
       {
+        label: 'Select Option',
+        hidden: true,
+        selected: true,
+        value: '',
+      },
+      {
         label: 'Option 1',
         value: 'value-1',
       },
@@ -94,6 +100,12 @@ export const withLabelHintAndError: Story = {
     },
     items: [
       {
+        label: 'Select Option',
+        hidden: true,
+        selected: true,
+        value: '',
+      },
+      {
         label: 'Option 1',
         value: 'value-1',
       },
@@ -111,15 +123,15 @@ export const withLabelHintAndError: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const textInput = canvas.getByTestId('unique-id') as HTMLSelectElement;
-    expect(globalThis.window.getComputedStyle(textInput).borderColor).toBe(
+    const select = canvas.getByTestId('unique-id') as HTMLSelectElement;
+    expect(globalThis.window.getComputedStyle(select).borderColor).toBe(
       'rgb(187, 37, 13)',
     );
 
     const label = canvas.getByText('Default Select');
     expect(label).toBeTruthy();
     expect(label).toHaveClass('gi-label');
-    expect(label.getAttribute('for')).toBe(textInput.getAttribute('id'));
+    expect(label.getAttribute('for')).toBe(select.getAttribute('id'));
 
     const hint = canvas.getByText(
       'This can be different to where you went before',
@@ -130,6 +142,11 @@ export const withLabelHintAndError: Story = {
     const error = canvas.getByText('Error message');
     expect(error).toBeTruthy();
     expect(error).toHaveClass('gi-error-text');
+
+    const placeholderOption = select.options[0];
+    expect(placeholderOption.textContent).toBe('Select Option');
+    expect(placeholderOption.hidden).toBe(true);
+    expect(placeholderOption.selected).toBe(true);
   },
 };
 
@@ -213,6 +230,12 @@ export const withGroups: Story = {
         label: 'Group 1',
         items: [
           {
+            label: 'Select Option',
+            hidden: true,
+            selected: true,
+            value: '',
+          },
+          {
             label: 'Option 1',
             value: 'value-1',
           },
@@ -229,6 +252,12 @@ export const withGroups: Story = {
       {
         label: 'Group 2',
         items: [
+          {
+            label: 'Select Option',
+            hidden: true,
+            selected: true,
+            value: '',
+          },
           {
             label: 'Option 4',
             value: 'value-4',

--- a/packages/html/ds/src/select/types.ts
+++ b/packages/html/ds/src/select/types.ts
@@ -18,6 +18,8 @@ export type SelectItemProps = {
   value: string;
   label: string;
   disabled?: boolean;
+  hidden?: boolean;
+  selected?: boolean;
 };
 
 export type SelectGroupItemProps = {

--- a/packages/react/ds/src/select/select.stories.tsx
+++ b/packages/react/ds/src/select/select.stories.tsx
@@ -21,8 +21,8 @@ export default meta;
 export const Default = {
   render: () => (
     <FormField label={{ text: 'Label' }}>
-      <Select aria-label="Select">
-        <SelectItem selected hidden>
+      <Select aria-label="Select" defaultValue="select-option">
+        <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
@@ -60,8 +60,13 @@ export const WithLabelHintAndError = {
       hint={{ text: 'This is a hint' }}
       error={{ text: 'This is an error' }}
     >
-      <Select aria-label="Select" data-testid="select" id="select">
-        <SelectItem selected hidden>
+      <Select
+        aria-label="Select"
+        data-testid="select"
+        id="select"
+        defaultValue="select-option"
+      >
+        <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
@@ -92,8 +97,8 @@ export const WithLabelHintAndError = {
 
 export const WithoutLabel = {
   render: () => (
-    <Select aria-label="Select">
-      <SelectItem selected hidden>
+    <Select aria-label="Select" defaultValue="select-option">
+      <SelectItem value="select-option" hidden>
         Select Option
       </SelectItem>
       <SelectItem value="value-1">Option 1</SelectItem>
@@ -105,8 +110,8 @@ export const WithoutLabel = {
 
 export const DisabledSelect = {
   render: () => (
-    <Select aria-label="Select" disabled>
-      <SelectItem selected hidden>
+    <Select aria-label="Select" defaultValue="select-option" disabled>
+      <SelectItem value="select-option" hidden>
         Select Option
       </SelectItem>
       <SelectItem value="value-1">Option 1</SelectItem>
@@ -124,8 +129,8 @@ export const DisabledSelect = {
 
 export const DisabledItem = {
   render: () => (
-    <Select aria-label="Select">
-      <SelectItem selected hidden>
+    <Select aria-label="Select" defaultValue="select-option">
+      <SelectItem value="select-option" hidden>
         Select Option
       </SelectItem>
       <SelectItem disabled value="value-1">
@@ -147,9 +152,13 @@ export const DisabledItem = {
 
 export const WithGroups = {
   render: () => (
-    <Select aria-label="Select" data-testid="select">
+    <Select
+      aria-label="Select"
+      data-testid="select"
+      defaultValue="select-option"
+    >
       <SelectGroupItem label="Group 1" data-testid="select-group">
-        <SelectItem selected hidden>
+        <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
@@ -158,7 +167,7 @@ export const WithGroups = {
       </SelectGroupItem>
 
       <SelectGroupItem label="Group 2">
-        <SelectItem selected hidden>
+        <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
         <SelectItem value="value-4">Option 4</SelectItem>
@@ -167,7 +176,7 @@ export const WithGroups = {
       </SelectGroupItem>
 
       <SelectGroupItem label="Group 3">
-        <SelectItem selected hidden>
+        <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
         <SelectItem value="value-7">Option 7</SelectItem>

--- a/packages/react/ds/src/select/select.stories.tsx
+++ b/packages/react/ds/src/select/select.stories.tsx
@@ -180,7 +180,7 @@ export const WithGroups = {
     const canvas = within(canvasElement);
 
     const select = canvas.getByTestId('select') as HTMLSelectElement;
-    expect(select.options.length).toBe(9);
+    expect(select.options.length).toBe(12);
 
     const optGroup1 = canvas.getByTestId('select-group');
     expect(optGroup1).toBeTruthy();

--- a/packages/react/ds/src/select/select.stories.tsx
+++ b/packages/react/ds/src/select/select.stories.tsx
@@ -22,6 +22,9 @@ export const Default = {
   render: () => (
     <FormField label={{ text: 'Label' }}>
       <Select aria-label="Select">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
         <SelectItem value="value-2">Option 2</SelectItem>
         <SelectItem value="value-3">Option 3</SelectItem>
@@ -34,6 +37,9 @@ export const Focus = {
   render: () => (
     <FormField label={{ text: 'Label', htmlFor: 'focus-select' }}>
       <Select id="focus-select" aria-label="Select" className="focus-select">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
         <SelectItem value="value-2">Option 2</SelectItem>
         <SelectItem value="value-3">Option 3</SelectItem>
@@ -55,6 +61,9 @@ export const WithLabelHintAndError = {
       error={{ text: 'This is an error' }}
     >
       <Select aria-label="Select" data-testid="select" id="select">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
         <SelectItem value="value-2">Option 2</SelectItem>
         <SelectItem value="value-3">Option 3</SelectItem>
@@ -84,6 +93,9 @@ export const WithLabelHintAndError = {
 export const WithoutLabel = {
   render: () => (
     <Select aria-label="Select">
+      <SelectItem selected hidden>
+        Select Option
+      </SelectItem>
       <SelectItem value="value-1">Option 1</SelectItem>
       <SelectItem value="value-2">Option 2</SelectItem>
       <SelectItem value="value-3">Option 3</SelectItem>
@@ -94,6 +106,9 @@ export const WithoutLabel = {
 export const DisabledSelect = {
   render: () => (
     <Select aria-label="Select" disabled>
+      <SelectItem selected hidden>
+        Select Option
+      </SelectItem>
       <SelectItem value="value-1">Option 1</SelectItem>
       <SelectItem value="value-2">Option 2</SelectItem>
       <SelectItem value="value-3">Option 3</SelectItem>
@@ -110,6 +125,9 @@ export const DisabledSelect = {
 export const DisabledItem = {
   render: () => (
     <Select aria-label="Select">
+      <SelectItem selected hidden>
+        Select Option
+      </SelectItem>
       <SelectItem disabled value="value-1">
         Option 1
       </SelectItem>
@@ -131,18 +149,27 @@ export const WithGroups = {
   render: () => (
     <Select aria-label="Select" data-testid="select">
       <SelectGroupItem label="Group 1" data-testid="select-group">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-1">Option 1</SelectItem>
         <SelectItem value="value-2">Option 2</SelectItem>
         <SelectItem value="value-3">Option 3</SelectItem>
       </SelectGroupItem>
 
       <SelectGroupItem label="Group 2">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-4">Option 4</SelectItem>
         <SelectItem value="value-5">Option 5</SelectItem>
         <SelectItem value="value-6">Option 6</SelectItem>
       </SelectGroupItem>
 
       <SelectGroupItem label="Group 3">
+        <SelectItem selected hidden>
+          Select Option
+        </SelectItem>
         <SelectItem value="value-7">Option 7</SelectItem>
         <SelectItem value="value-8">Option 8</SelectItem>
         <SelectItem value="value-9">Option 9</SelectItem>


### PR DESCRIPTION
## Description
Update select option with placeholder text on React and HTML lib.

![Screenshot 2025-05-09 at 12 22 47](https://github.com/user-attachments/assets/8fb761ac-bb53-45d8-b7be-bdcdf49aba62)
![Screenshot 2025-05-09 at 12 23 00](https://github.com/user-attachments/assets/201cc14e-eae8-4313-830a-ecacd7389c07)


## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [X] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.