### PR TITLE
fix: extend select option className

### DIFF
--- a/packages/react/ds/src/select/select.stories.tsx
+++ b/packages/react/ds/src/select/select.stories.tsx
@@ -25,7 +25,9 @@ export const Default = {
         <SelectItem value="select-option" hidden>
           Select Option
         </SelectItem>
-        <SelectItem value="value-1">Option 1</SelectItem>
+        <SelectItem value="value-1" className="gi-p-10">
+          Option 1
+        </SelectItem>
         <SelectItem value="value-2">Option 2</SelectItem>
         <SelectItem value="value-3">Option 3</SelectItem>
       </Select>

--- a/packages/react/ds/src/select/select.tsx
+++ b/packages/react/ds/src/select/select.tsx
@@ -24,9 +24,13 @@ export const SelectGroupItem = ({
   </optgroup>
 );
 
-export const SelectItem = ({ children, ...props }: SelectItemProps) => (
+export const SelectItem = ({
+  children,
+  className,
+  ...props
+}: SelectItemProps) => (
   <option
-    className={cn('gi-select-option', props.className)}
+    className={cn('gi-select-option', className)}
     aria-selected={props.selected ? 'true' : 'false'}
     {...props}
   >


### PR DESCRIPTION
## Description
Extend select option class name. Here in this screenshot I have extended `gi-p-10` which gets added with `gi-select-option`.
![Screenshot 2025-05-16 at 16 43 27](https://github.com/user-attachments/assets/b1957248-ef39-4429-a84b-e49d04005571)


## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.
