### PR TITLE
fix: add button type to button group item

### DIFF
--- a/packages/react/ds/src/button-group/button-group.test.tsx
+++ b/packages/react/ds/src/button-group/button-group.test.tsx
@@ -1,0 +1,46 @@
+import { userEvent } from '@testing-library/user-event';
+import { renderComponent, cleanup } from '../test-utilities.js';
+import { ButtonGroup, ButtonGroupItem } from './button-group.js';
+
+describe('buttonGroup', () => {
+  afterEach(cleanup);
+
+  it('should render the button group', () => {
+    const screen = renderComponent(
+      <ButtonGroup name="test" size="medium" defaultValue="1">
+        <ButtonGroupItem value="1">Button 1</ButtonGroupItem>
+        <ButtonGroupItem value="2">Button 2</ButtonGroupItem>
+      </ButtonGroup>,
+    );
+    const buttonOneElement = screen.getByText('Button 1');
+    const buttonTwoElement = screen.getByText('Button 2');
+
+    expect(buttonOneElement).toBeDefined();
+    expect(buttonOneElement).toHaveClass('gi-btn-primary-dark');
+    expect(buttonOneElement).toHaveAttribute('aria-checked', 'true');
+
+    expect(buttonTwoElement).toBeDefined();
+    expect(buttonTwoElement).not.toHaveClass('gi-btn-primary-dark');
+    expect(buttonTwoElement).toHaveAttribute('aria-checked', 'false');
+  });
+  it('should not submit the form on press a button group items', async () => {
+    const onSubmitSpy = vi.fn();
+    const user = userEvent.setup();
+    const screen = renderComponent(
+      <form onSubmit={onSubmitSpy}>
+        <ButtonGroup name="test" size="medium" defaultValue="1">
+          <ButtonGroupItem value="1">Button 1</ButtonGroupItem>
+          <ButtonGroupItem value="2">Button 2</ButtonGroupItem>
+        </ButtonGroup>
+        ,
+      </form>,
+    );
+    const buttonOneElement = screen.getByText('Button 1');
+    const buttonTwoElement = screen.getByText('Button 2');
+
+    await user.click(buttonOneElement);
+    await user.click(buttonTwoElement);
+
+    expect(onSubmitSpy).toBeCalledTimes(0);
+  });
+});

--- a/packages/react/ds/src/button-group/button-group.tsx
+++ b/packages/react/ds/src/button-group/button-group.tsx
@@ -4,11 +4,11 @@ import {
   FC,
   PropsWithChildren,
   useContext,
-  useId,
   useState,
 } from 'react';
 import { Button } from '../button/button.js';
 import { ButtonAppearance, ButtonSize } from '../button/types.js';
+import { useDomId } from '../hooks/use-dom-id.js';
 
 type ButtonGroupContextType = {
   selectedValue?: string;
@@ -71,6 +71,7 @@ export const ButtonGroupItem: FC<ButtonGroupItemProps> = ({
       role={customRole || 'radio'}
       aria-checked={ariaChecked === undefined ? isSelected : ariaChecked}
       aria-label={ariaLabel}
+      type="button"
     >
       {children}
     </Button>
@@ -103,7 +104,7 @@ export const ButtonGroup: FC<ButtonGroupProps> = ({
     defaultValue,
   );
 
-  const groupId = useId();
+  const groupId = useDomId();
 
   return (
     <ButtonGroupContext.Provider

--- a/packages/react/ds/src/hooks/use-dom-id.ts
+++ b/packages/react/ds/src/hooks/use-dom-id.ts
@@ -1,0 +1,22 @@
+/**
+ * A React hook that generates a DOM-safe unique ID by replacing colons with hyphens.
+ *
+ * This hook addresses the issue where React 18's useId() generates IDs containing colons,
+ * which are invalid in certain DOM contexts (see https://github.com/facebook/react/pull/32001).
+ *
+ * @returns A string containing a unique, DOM-safe identifier where all colons have been replaced with hyphens
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const id = useDomId();
+ *   return <div id={id}>Content</div>;
+ * }
+ * ```
+ */
+import { useId, useMemo } from 'react';
+
+export function useDomId() {
+  const idRef = useId();
+  return useMemo(() => idRef.replaceAll(':', '-'), [idRef]);
+}


### PR DESCRIPTION
## Description

When a `ButtonGroupItem` component is placed inside a `<form>` element, clicking it triggers the form submission. This behavior occurs because the rendered button defaults to `type="submit"`.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [X] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

<!-- List any related issues or pull requests (e.g., "Fixes #123"). -->
