### PR TITLE
docs: add temporary helper for new folder structure

### DIFF
--- a/apps/docs/src/components/document/components/component-status-table.tsx
+++ b/apps/docs/src/components/document/components/component-status-table.tsx
@@ -10,11 +10,11 @@ import {
   TableData,
   TableRow,
   Tag,
-  TagTypeEnum,
 } from '@govie-ds/react';
 import Image from 'next/image';
 import { Fragment } from 'react';
 import { TagFromStatus } from './tag-from-status';
+import { getComponentsTemp } from '@/lib/helper';
 
 export function ComponentStatusPill({ status }: { status: ComponentStatus }) {
   const tagProps = TagFromStatus(status);
@@ -167,7 +167,7 @@ export function ComponentStatusBlock({ componentId }: { componentId: string }) {
 }
 
 export function ComponentStatusTable() {
-  const components = getComponents();
+  const components = getComponentsTemp();
 
   const componentStatuses = components.map((component) => {
     const figmaPlatform = component.statuses.find(

--- a/apps/docs/src/components/document/components/component-status-table.tsx
+++ b/apps/docs/src/components/document/components/component-status-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { GovieLink } from '@/components/navigation/custom-link';
 import analytics from '@/lib/analytics';
-import { ComponentStatus, getComponents } from '@/lib/components';
+import { ComponentStatus } from '@/lib/components';
 import {
   Button,
   Paragraph,
@@ -14,7 +14,7 @@ import {
 import Image from 'next/image';
 import { Fragment } from 'react';
 import { TagFromStatus } from './tag-from-status';
-import { getComponentsTemp } from '@/lib/helper';
+import { getComponents } from '@/lib/helper';
 
 export function ComponentStatusPill({ status }: { status: ComponentStatus }) {
   const tagProps = TagFromStatus(status);
@@ -167,7 +167,7 @@ export function ComponentStatusBlock({ componentId }: { componentId: string }) {
 }
 
 export function ComponentStatusTable() {
-  const components = getComponentsTemp();
+  const components = getComponents();
 
   const componentStatuses = components.map((component) => {
     const figmaPlatform = component.statuses.find(

--- a/apps/docs/src/lib/helper.ts
+++ b/apps/docs/src/lib/helper.ts
@@ -1,20 +1,3 @@
-/**
- * @function getComponentsTemp
- * @description
- * Temporary utility function to fetch and normalize component metadata
- * from mixed-format documents. It merges legacy documents (without explicit
- * libraries) and newer documents (with `libraries` field), associating them
- * with appropriate platforms (`figma`, `react`, `global`) and statuses.
- *
- * The function generates a standardized list of ComponentsDocument objects,
- * each including platform-specific statuses and links to Storybook previews.
- *
- * ⚠️ This function will be removed once all component documents are migrated
- * to the new file format structure (design, react, html).
- *
- * @returns {ComponentsDocument[]} Sorted list of normalized component metadata.
- */
-
 import { sortBy, groupBy } from 'lodash';
 import { getAll } from './documents';
 
@@ -99,7 +82,24 @@ function mapPlatformName(platform: string): ComponentPlatformId {
   }
 }
 
-export function getComponentsTemp(): ComponentsDocument[] {
+/**
+ * @function getComponents
+ * @description
+ * Temporary utility function to fetch and normalize component metadata
+ * from mixed-format documents. It merges legacy documents (without explicit
+ * libraries) and newer documents (with `libraries` field), associating them
+ * with appropriate platforms (`figma`, `react`, `global`) and statuses.
+ *
+ * The function generates a standardized list of ComponentsDocument objects,
+ * each including platform-specific statuses and links to Storybook previews.
+ *
+ * ⚠️ This function will be removed once all component documents are migrated
+ * to the new file format structure (design, react, html).
+ *
+ * @returns {ComponentsDocument[]} Sorted list of normalized component metadata.
+ */
+
+export function getComponents(): ComponentsDocument[] {
   const componentsDocuments = getAll().filter((document) => document.component);
 
   const componentWithLibraries = componentsDocuments.filter(

--- a/apps/docs/src/lib/helper.ts
+++ b/apps/docs/src/lib/helper.ts
@@ -1,0 +1,206 @@
+/**
+ * @function getComponentsTemp
+ * @description
+ * Temporary utility function to fetch and normalize component metadata
+ * from mixed-format documents. It merges legacy documents (without explicit
+ * libraries) and newer documents (with `libraries` field), associating them
+ * with appropriate platforms (`figma`, `react`, `global`) and statuses.
+ *
+ * The function generates a standardized list of ComponentsDocument objects,
+ * each including platform-specific statuses and links to Storybook previews.
+ *
+ * ⚠️ This function will be removed once all component documents are migrated
+ * to the new file format structure (design, react, html).
+ *
+ * @returns {ComponentsDocument[]} Sorted list of normalized component metadata.
+ */
+
+import { sortBy, groupBy } from 'lodash';
+import { getAll } from './documents';
+
+export type ComponentStatus =
+  | 'alpha'
+  | 'beta'
+  | 'stable'
+  | 'considering'
+  | 'not-available'
+  | 'deprecated';
+
+export type ComponentPlatformId = 'figma' | 'global' | 'react';
+
+export type ComponentPlatform = {
+  id: ComponentPlatformId;
+  href?: string;
+};
+
+export type ComponentPlatformStatus = {
+  platform: ComponentPlatform;
+  status?: ComponentStatus;
+  designReviewed?: boolean;
+  accessibilityReviewed?: boolean;
+};
+
+export type ComponentsDocument = {
+  id: string;
+  name: string;
+  slug: string;
+  statuses: ComponentPlatformStatus[];
+  component: ComponentMetadata;
+};
+
+export type ComponentMetadata = {
+  id: string;
+  link?: string | undefined;
+  status: 'not-available' | 'alpha' | 'beta' | 'stable';
+  properties?: {
+    name: string;
+    fields: {
+      name: string;
+      ofType: string;
+      description: string;
+      defaultValue?: string | undefined;
+      required: boolean;
+    }[];
+  }[];
+  stories?: {
+    name: string;
+    url: string;
+  }[];
+};
+
+const globalHtmlStorybookBaseUrl = '/storybook-html/';
+const reactStorybookBaseUrl = '/storybook-react/';
+
+function extractBaseIdAndPlatform(id: string): {
+  baseId: string;
+  platform?: string;
+} {
+  const parts = id.split('/');
+  if (parts.length > 3) {
+    const platform = parts[parts.length - 1];
+    if (['design', 'html', 'react'].includes(platform)) {
+      const baseId = parts.slice(0, -1).join('/');
+      return { baseId, platform };
+    }
+  }
+  return { baseId: id };
+}
+
+function mapPlatformName(platform: string): ComponentPlatformId {
+  switch (platform) {
+    case 'design':
+      return 'figma';
+    case 'html':
+      return 'global';
+    case 'react':
+      return 'react';
+    default:
+      return platform as ComponentPlatformId;
+  }
+}
+
+export function getComponentsTemp(): ComponentsDocument[] {
+  const componentsDocuments = getAll().filter((document) => document.component);
+
+  const componentWithLibraries = componentsDocuments.filter(
+    (component) => component.libraries,
+  );
+
+  const componentWithoutLibraries = componentsDocuments.filter(
+    (cd) => !cd.libraries,
+  );
+
+  const groupedComponentsWithoutLibraries = groupBy(
+    componentWithoutLibraries,
+    (component) => extractBaseIdAndPlatform(component.id).baseId,
+  );
+
+  const mergedComponentsFromWithoutLibraries: ComponentsDocument[] =
+    Object.entries(groupedComponentsWithoutLibraries).map(
+      ([baseId, components]) => {
+        const baseComponent = components[0];
+        const libraries = components.map((comp) => {
+          const { platform } = extractBaseIdAndPlatform(comp.id);
+          const mappedPlatform = platform ? mapPlatformName(platform) : 'figma';
+
+          return {
+            link: comp.component?.link,
+            platform: mappedPlatform,
+            status: comp.component?.status,
+            type: '__UNNAMED__',
+          };
+        });
+
+        const mergedComponent = {
+          ...baseComponent,
+          id: baseId,
+          libraries,
+        };
+
+        return {
+          id: baseId,
+          name: mergedComponent.title,
+          slug: mergedComponent.slug,
+          component: mergedComponent.component,
+          statuses: libraries.map((library) => {
+            let baseUrl = '';
+            switch (library.platform) {
+              case 'react': {
+                baseUrl = reactStorybookBaseUrl;
+                break;
+              }
+              case 'global': {
+                baseUrl = globalHtmlStorybookBaseUrl;
+                break;
+              }
+            }
+            return {
+              status: library.status,
+              platform: {
+                id: library.platform,
+                href: library.link ? `${baseUrl}${library.link}` : undefined,
+              },
+            } as ComponentPlatformStatus;
+          }),
+        } as ComponentsDocument;
+      },
+    );
+
+  const processedComponentsWithLibraries = componentWithLibraries.map(
+    (componentsDocument) =>
+      ({
+        id: componentsDocument.id,
+        name: componentsDocument.title,
+        slug: componentsDocument.slug,
+        component: componentsDocument.component,
+        statuses:
+          componentsDocument.libraries?.map((status) => {
+            let baseUrl = '';
+            switch (status.platform) {
+              case 'react': {
+                baseUrl = reactStorybookBaseUrl;
+                break;
+              }
+              case 'global': {
+                baseUrl = globalHtmlStorybookBaseUrl;
+                break;
+              }
+            }
+            return {
+              status: status.status,
+              platform: {
+                id: status.platform,
+                href: status.link ? `${baseUrl}${status.link}` : undefined,
+              },
+            } as ComponentPlatformStatus;
+          }) || [],
+      }) as ComponentsDocument,
+  );
+
+  const allComponents = [
+    ...processedComponentsWithLibraries,
+    ...mergedComponentsFromWithoutLibraries,
+  ];
+
+  return sortBy(allComponents, 'name');
+}

--- a/packages/html/ds/src/file-upload/file-upload.stories.ts
+++ b/packages/html/ds/src/file-upload/file-upload.stories.ts
@@ -5,7 +5,7 @@ import { beautifyHtmlNode } from '../storybook/storybook';
 import { FileUploadProps } from './types';
 
 const meta: Meta<FileUploadProps> = {
-  title: 'Form/FileUpload',
+  title: 'Form/InputFile',
 };
 
 export default meta;


### PR DESCRIPTION
## Description

- The old structure file structure follows `getComponents` schema which is dependant on file names.
- The new structure now have `react.mdx`, `html.mdx` and `design.mdx` files.

Instead of refactoring `getComponents` component to accept 2 formats which is being used on many places e.g. `storybook-frame.tsx` and others. I created a **temporary** file `helper.ts` which exports `getComponentsTemp` to be used on component status table. This will be removed later once we have all the components following the consistent pattern.  

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.