### PR TITLE
chore: update menu input type to button for screen reader

### DIFF
--- a/packages/react/ds/src/header/components/header-slot.tsx
+++ b/packages/react/ds/src/header/components/header-slot.tsx
@@ -47,7 +47,7 @@ const DrawerTrigger = ({
           className="gi-block gi-w-0 gi-absolute gi-h-0"
           id={`ItemActionDrawerTrigger-${index}`}
           data-index={index}
-          type="checkbox"
+          type="button"
         />
         {label && <span className="label">{label}</span>}
         {icon && (
@@ -103,7 +103,7 @@ export const SlotItemAction = ({ item, index }: HeaderSlotProps) => {
         data-index={index}
         aria-expanded="false"
         aria-controls={`SlotContainer-${index + 1}`}
-        type="checkbox"
+        type="button"
       />
       {item.label && <span className="label">{item.label}</span>}
       {item.icon && (


### PR DESCRIPTION
## Description
This should fix the screen reader issue that says "Tickbox" or "Button, group" using Voice Over or other tools.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
We should also test other components similarly.