### PR TITLE
docs: download svg icon button

### DIFF
--- a/apps/docs/src/components/document/resources/copy-to-clipboard-button.tsx
+++ b/apps/docs/src/components/document/resources/copy-to-clipboard-button.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Icon, IconButton } from '@govie-ds/react';
+import { IconButton } from '@govie-ds/react';
 import copy from 'copy-text-to-clipboard';
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/cn';

--- a/apps/docs/src/components/document/resources/download-icon-button.tsx
+++ b/apps/docs/src/components/document/resources/download-icon-button.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { IconButton } from '@govie-ds/react';
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/cn';
+import analytics from '@/lib/analytics';
+
+export function DownloadIconButton({
+  text,
+  name,
+}: {
+  name: string;
+  text: string;
+}) {
+  const [downloaded, setDownloaded] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (downloaded) {
+        setDownloaded(false);
+      }
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [downloaded]);
+
+  const handleDownload = () => {
+    const safeName = name.trim().replace(/\s+/g, '_');
+
+    analytics.trackEvent({
+      category: 'download content',
+      action: 'click',
+      name,
+    });
+
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${safeName}.txt`;
+    link.click();
+
+    URL.revokeObjectURL(url);
+    setDownloaded(true);
+  };
+
+  return (
+    <IconButton
+      onClick={handleDownload}
+      icon={{ icon: downloaded ? 'check' : 'download' }}
+      size="small"
+      appearance="light"
+      className={cn({
+        'text-green-600': downloaded,
+        'text-gray-600': !downloaded,
+      })}
+    />
+  );
+}

--- a/apps/docs/src/components/document/resources/download-icon-button.tsx
+++ b/apps/docs/src/components/document/resources/download-icon-button.tsx
@@ -24,7 +24,7 @@ export function DownloadIconButton({
   }, [downloaded]);
 
   const handleDownload = () => {
-    const safeName = name.trim().replace(/\s+/g, '_');
+    const safeName = name.toLowerCase().trim().replace(/\s+/g, '_');
 
     analytics.trackEvent({
       category: 'download content',
@@ -32,12 +32,12 @@ export function DownloadIconButton({
       name,
     });
 
-    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const blob = new Blob([text], { type: 'image/svg+xml;charset=utf-8' });
     const url = URL.createObjectURL(blob);
 
     const link = document.createElement('a');
     link.href = url;
-    link.download = `${safeName}.txt`;
+    link.download = `${safeName}.svg`;
     link.click();
 
     URL.revokeObjectURL(url);

--- a/apps/docs/src/components/document/resources/download-svg.tsx
+++ b/apps/docs/src/components/document/resources/download-svg.tsx
@@ -1,0 +1,16 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { DownloadIconButton } from './download-icon-button';
+
+export async function DownloadSvg({
+  src,
+  name,
+}: {
+  src: string;
+  name: string;
+}) {
+  const absolutePath = path.join(process.cwd(), 'public', src);
+  const svgContent = await fs.readFile(absolutePath, 'utf8');
+
+  return <DownloadIconButton text={svgContent} name={name} />;
+}

--- a/apps/docs/src/components/document/resources/logos.tsx
+++ b/apps/docs/src/components/document/resources/logos.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import { Card } from '../common/card';
 import { Image } from '../common/image';
 import { CopySvg } from './copy-svg';
+import { DownloadSvg } from './download-svg';
 
 type Logo = {
   id: string;
@@ -92,7 +93,8 @@ function LogoGroup({ name, logos }: { name: string; logos: Logo[] }) {
                     height={logo.height}
                   />
                 </div>
-                <div className="flex justify-end">
+                <div className="flex justify-end gap-1">
+                  <DownloadSvg name={logo.name} src={logo.src} />
                   <CopySvg src={logo.src} />
                 </div>
               </Card>


### PR DESCRIPTION
## Description
Add download svg icon button along with copy to clipboard.

![Screenshot 2025-06-11 at 10 37 33](https://github.com/user-attachments/assets/8706c77b-3bb3-4c0e-9bc3-e19781577720)


## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.