### PR TITLE
fix: update combo box focus state

### DIFF
--- a/apps/docs/content/3-components/2-library/combo-box.mdx
+++ b/apps/docs/content/3-components/2-library/combo-box.mdx
@@ -228,7 +228,7 @@ component:
   <TabPanel value="tab11">
   ```html
     <div data-module="gieds-combobox" class="gi-combobox-container">
-      <div role="group" data-module="gieds-dropdown-item">
+      <div role="group" data-module="gieds-dropdown-item" class="gi-combobox-dropdown-item">
         <button class="gi-btn gi-btn-flat-dark gi-btn-large gi-combobox-toggle" data-testid="combobox-toggle">
           <div class="gi-combobox-toggle-content">
             <p class="gi-paragraph-md gi-text-start gi-whitespace-normal">Organisations</p>
@@ -275,7 +275,7 @@ component:
           </div>
         </div>
       </div>
-      <div role="group" data-module="gieds-dropdown-item">
+      <div role="group" data-module="gieds-dropdown-item" class="gi-combobox-dropdown-item">
         <button class="gi-btn gi-btn-flat-dark gi-btn-large gi-combobox-toggle" data-testid="combobox-toggle">
           <div class="gi-combobox-toggle-content">
             <p class="gi-paragraph-md gi-text-start gi-whitespace-normal">Topic (without search)</p>

--- a/packages/design/tailwind/css/components/combo-box.css
+++ b/packages/design/tailwind/css/components/combo-box.css
@@ -1,58 +1,70 @@
 .gi-combobox-container {
-  @apply gi-max-w-[400px] gi-border-t;
+  @apply gi-max-w-[400px];
 }
-.gi-combobox-toggle {
-  @apply gi-border-b-color-border-system-neutral-muted gi-border-b
-    gi-relative !gi-h-[unset] gi-z-1 gi-px-2 gi-py-4 gi-flex 
-    gi-justify-between gi-cursor-pointer gi-w-full hover:gi-bg-gray-200;
+
+.gi-combobox-dropdown-item {
+  @apply gi-border-b first:gi-border-t;
 }
 
 .gi-combobox-toggle {
-  @apply gi-border-t-transparent gi-border-t-sm gi-relative gi-z-1 hover:gi-bg-color-surface-system-neutral-interactive-hover gi-border-b gi-px-2 gi-py-4 gi-flex gi-justify-between gi-cursor-pointer gi-w-full gi-focus-state-outline gi-focus-state-border-sm-rounded focus:gi-bg-color-surface-system-neutral-interactive-hover;
+  @apply gi-flex gi-px-2 gi-py-4 gi-relative gi-z-1 !gi-h-[unset] gi-justify-between gi-cursor-pointer gi-w-full
+    gi-border-t-transparent gi-border-t-sm
+    hover:gi-bg-color-surface-system-neutral-interactive-hover
+    focus:gi-bg-color-surface-system-neutral-interactive-hover gi-focus-state-outline gi-focus-state-border-sm-rounded;
 }
 
-.gi-combobox-toggle-open {
-  @apply gi-border-b-0;
-}
 .gi-combobox-toggle-content {
   @apply gi-flex gi-gap-2;
 }
+
 .gi-combobox-toggle-content > p {
   @apply gi-mb-0;
 }
+
 .gi-combobox-dropdown-container-open {
-  @apply gi-bg-color-surface-system-neutral-layer1 gi-relative gi-border-b gi-block;
+  @apply gi-bg-color-surface-system-neutral-layer1 gi-relative gi-block;
 }
+
 .gi-combobox-dropdown-container-close {
-  @apply gi-bg-color-surface-system-neutral-layer1 gi-relative gi-border-b gi-hidden;
+  @apply gi-bg-color-surface-system-neutral-layer1 gi-relative gi-hidden;
 }
+
 .gi-combobox-search {
   @apply gi-py-4 gi-px-3 gi-relative;
 }
+
 .gi-combobox-search-input {
   @apply gi-pt-0 gi-pb-0 gi-mb-0;
 }
+
 .gi-combobox-search-input input {
   @apply gi-pl-3;
 }
+
 .gi-combobox-search-icon {
   @apply gi-absolute gi-right-4 gi-top-5 gi-z-100 gi-cursor-pointer;
 }
+
 .gi-combobox-checkbox-container {
   @apply gi-max-h-64 gi-overflow-y-auto gi-overflow-x-hidden gi-pt-2;
 }
+
 .gi-combobox-checkbox-container .gi-input-checkbox-container {
   @apply gi-items-center;
 }
+
 .gi-combobox-checkbox-paragraph {
   @apply gi-text-center gi-w-full;
 }
+
 .gi-combobox-checkbox {
   @apply gi-px-3 hover:gi-bg-color-surface-system-neutral-interactive-hover;
 }
+
 .gi-combobox-checkbox input {
   @apply gi-min-w-6;
 }
+
 .gi-combobox-checkbox label {
   @apply gi-w-full gi-py-2;
 }

--- a/packages/html/ds/src/helpers/combobox.ts
+++ b/packages/html/ds/src/helpers/combobox.ts
@@ -16,6 +16,7 @@ export const createComboBox = (arguments_: ComboBoxProps) => {
     const itemContainer = document.createElement('div');
     comboBox.append(itemContainer);
     itemContainer.role = 'group';
+    itemContainer.className = 'gi-combobox-dropdown-item';
     itemContainer.dataset.module = 'gieds-dropdown-item';
 
     const button = document.createElement('button');

--- a/packages/react/ds/src/combo-box/dropdown-item.tsx
+++ b/packages/react/ds/src/combo-box/dropdown-item.tsx
@@ -67,7 +67,11 @@ export const DropdownItem = ({
   };
 
   return (
-    <div role="group" aria-label={`${children} dropdown`}>
+    <div
+      role="group"
+      aria-label={`${children} dropdown`}
+      className="gi-combobox-dropdown-item"
+    >
       <Button
         variant="flat"
         appearance="dark"


### PR DESCRIPTION
## Description
- Removed duplicate `gi-combobox-toggle`.
- Add `gi-combobox-dropdown-item` class that deals separately with border top and bottom.
- Removed unnecessary border bottom classes that were conflicting with the focus state of native button.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.