### PR TITLE
fix: add input password html component and associated documentation

### DIFF
--- a/apps/docs/content/3-components/2-library/input-password/html.mdx
+++ b/apps/docs/content/3-components/2-library/input-password/html.mdx
@@ -1,0 +1,40 @@
+---
+title: Input Password
+description: Input Password HTML Component
+status: stable
+component:
+  id: 'input-password-html'
+  link: '/docs/form-inputpassword--docs'
+  status: 'stable'
+
+  stories:
+    - name: 'default'
+      url: '/story/form-inputpassword--default'
+---
+
+# Input Password
+
+<Section current="html">
+
+<ComponentPreview>
+  <FormField
+    label={{
+      text: 'Password',
+      htmlFor: 'text-password-id',
+    }}
+  >
+    <InputPassword placeholder="Placeholder" data-testid="text-password-id" />
+  </FormField>
+</ComponentPreview>
+
+## Examples
+
+### Default
+
+<StorybookFrame
+  heightClassName="h-max"
+  componentId="input-password-html"
+  story="default"
+/>
+
+</Section>

--- a/apps/docs/src/components/document/components/section.tsx
+++ b/apps/docs/src/components/document/components/section.tsx
@@ -16,7 +16,7 @@ const baseTabs = [
     id: 'html',
     title: 'HTML',
     href: '../html/',
-    excludes: ['input-password'],
+    excludes: [],
   },
   {
     id: 'react',

--- a/packages/html/ds/src/common/instances.ts
+++ b/packages/html/ds/src/common/instances.ts
@@ -1,4 +1,5 @@
 import { Accordion } from '../accordion/accordion';
+import { InputPassword } from '../input-password/input-password';
 import { Alert } from '../alert/alert';
 import { ComboBox } from '../combo-box/combo-box';
 import { CookieBanner } from '../cookie-banner/cookie-banner';
@@ -30,8 +31,8 @@ const componentRegistry = {
   Alert,
   Toast,
   Accordion,
+  InputPassword,
   Drawer,
-  // TODO: additional component classes
 } as const;
 
 export type ComponentRegistryKey = keyof typeof componentRegistry;

--- a/packages/html/ds/src/helpers/forms.tsx
+++ b/packages/html/ds/src/helpers/forms.tsx
@@ -274,6 +274,69 @@ export const createTextInput = (arguments_: TextInputProps) => {
   return formField;
 };
 
+export const createInputPassword = (arguments_: TextInputProps) => {
+  const formField = createFormField(arguments_);
+
+  const container = document.createElement('div');
+  container.className =
+    `${arguments_.className || ''} gi-input-text-container`.trim();
+
+  const inner = document.createElement('div');
+  inner.className = 'gi-input-text-inner';
+
+  const input = document.createElement('input');
+  input.type = 'password';
+  input.className = 'gi-input-text';
+
+  if (arguments_.id) {
+    input.id = arguments_.id;
+  }
+
+  if (arguments_.name) {
+    input.name = arguments_.name;
+  }
+
+  if (arguments_.placeholder) {
+    input.placeholder = arguments_.placeholder;
+  }
+
+  if (arguments_.dataTestId) {
+    input.dataset.testid = arguments_.dataTestId;
+  }
+
+  if (arguments_.disabled) {
+    input.disabled = true;
+  }
+
+  if (arguments_.halfFluid) {
+    inner.classList.add('gi-input-half-width');
+  }
+
+  inner.append(input);
+
+  const endElement = document.createElement('div');
+  endElement.className = 'gi-input-text-end-element';
+  endElement.dataset.suffix = `${!!arguments_.suffix}`;
+  endElement.append(
+    createIconButton({
+      id: 'input-password-visibility-icon',
+      icon: {
+        icon: 'visibility',
+      },
+      variant: 'flat',
+      size: 'small',
+      appearance: 'dark',
+      disabled: arguments_.disabled,
+    }),
+  );
+
+  inner.append(endElement);
+  container.append(inner);
+  formField.append(container);
+
+  return formField;
+};
+
 export const createRadio = (arguments_: RadioProps) => {
   let widthClass = 'gi-w-8';
   let sizeClass = 'gi-input-radio-medium';

--- a/packages/html/ds/src/index.ts
+++ b/packages/html/ds/src/index.ts
@@ -9,6 +9,7 @@ import { initHeader } from './header/header.js';
 import { initCheckboxes } from './input-checkbox/input-checkbox.js'; /* eslint-disable-line import-x/order */
 import { initComboBox } from './combo-box/combo-box.js'; /* eslint-disable-line import-x/order */
 import { initModal } from './modal/modal.js';
+import { initPassword } from './input-password/input-password.js'; /* eslint-disable-line import-x/order */
 import { initRadios } from './radio/radio.js';
 import { initTabs } from './tabs/tabs.js';
 import { initTextarea } from './textarea/textarea.js';
@@ -46,6 +47,7 @@ export function initGovIe() {
   initAlert();
   initToast();
   initAccordion();
+  initPassword();
   initUtilities();
 }
 

--- a/packages/html/ds/src/input-password/input-password.stories.ts
+++ b/packages/html/ds/src/input-password/input-password.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createInputPassword } from '../helpers/forms';
+import { LabelSize } from '../label/types';
+import { beautifyHtmlNode } from '../storybook/storybook';
+import { InputPasswordProps } from './types';
+import { HintSize } from '../hint-text/types';
+import { ErrorSize } from '../error-text/types';
+
+const meta: Meta<InputPasswordProps> = {
+  title: 'Form/InputPassword',
+  parameters: {
+    docs: {
+      description: {
+        component: 'Input Password component.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<InputPasswordProps>;
+
+const createElement = (arguments_: InputPasswordProps) => {
+  const component = createInputPassword(arguments_);
+  return beautifyHtmlNode(component);
+};
+
+export const Default: Story = {
+  args: {
+    id: 'input-password-default-id',
+    halfFluid: true,
+    label: {
+      content: 'Password',
+      htmlFor: 'input-password-default-id',
+      size: LabelSize.Medium,
+    },
+    placeholder: 'Password',
+  },
+  render: (arguments_) => createElement(arguments_),
+};
+
+export const LabelAndHint: Story = {
+  args: {
+    id: 'input-password-label-hint',
+    halfFluid: true,
+    label: {
+      content: 'Password',
+      htmlFor: 'input-password-label-hint',
+      size: LabelSize.Medium,
+    },
+    hint: {
+      content: 'Support text',
+      size: HintSize.Medium,
+    },
+    placeholder: 'Password',
+  },
+  render: (arguments_) => createElement(arguments_),
+};
+
+export const LabelHintAndError: Story = {
+  args: {
+    id: 'input-password-label-hint-and-error',
+    halfFluid: true,
+    label: {
+      content: 'Password',
+      htmlFor: 'input-password-label-hint-and-error',
+      size: LabelSize.Medium,
+    },
+    hint: {
+      content: 'Support text',
+      size: HintSize.Medium,
+    },
+    error: {
+      content: 'Error text',
+      size: ErrorSize.Medium,
+    },
+    placeholder: 'Password',
+  },
+  render: (arguments_) => createElement(arguments_),
+};

--- a/packages/html/ds/src/input-password/input-password.ts
+++ b/packages/html/ds/src/input-password/input-password.ts
@@ -1,0 +1,67 @@
+import {
+  BaseComponent,
+  BaseComponentOptions,
+  initialiseModule,
+} from '../common/component';
+// import { createIconButton } from '../helpers/buttons';
+
+export type InputPasswordOptions = BaseComponentOptions;
+
+export class InputPassword extends BaseComponent<InputPasswordOptions> {
+  // inputEl: HTMLInputElement | null;
+  // toggleButton: HTMLElement | null;
+
+  constructor(options: InputPasswordOptions) {
+    super(options);
+
+    console.log('constructor!');
+
+    // this.inputEl =
+    //   options.element.querySelector<HTMLInputElement>('.gi-input-text');
+    // this.toggleButton = options.element.querySelector<HTMLElement>(
+    //   '#input-password-visibility-icon',
+    // );
+  }
+  initComponent() {
+    // if (!this.inputEl || !this.toggleButton) return;
+    // this.toggleButton.addEventListener('click', this.toggleHandler);
+    console.log('init!');
+  }
+
+  destroyComponent() {
+    console.log('destroyed!');
+    // if (this.toggleButton) {
+    //   this.toggleButton.removeEventListener('click', this.toggleHandler);
+    // }
+  }
+
+  // private toggleHandler = () => {
+  //   if (!this.inputEl || !this.toggleButton) return;
+
+  //   const isPassword = this.inputEl.type === 'password';
+  //   this.inputEl.type = isPassword ? 'text' : 'password';
+
+  //   // Replace entire icon button
+  //   const newIconButton = createIconButton({
+  //     id: 'input-password-visibility-icon',
+  //     icon: {
+  //       icon: isPassword ? 'visibility_off' : 'visibility',
+  //     },
+  //     variant: 'flat',
+  //     size: 'small',
+  //     appearance: 'dark',
+  //     disabled: this.inputEl.disabled,
+  //   });
+
+  //   // Rebind the event listener
+  //   newIconButton.addEventListener('click', this.toggleHandler);
+
+  //   this.toggleButton.replaceWith(newIconButton);
+  //   this.toggleButton = newIconButton;
+  // };
+}
+
+export const initPassword = initialiseModule({
+  name: 'input-password',
+  component: 'InputPassword',
+});

--- a/packages/html/ds/src/input-password/types.ts
+++ b/packages/html/ds/src/input-password/types.ts
@@ -1,0 +1,6 @@
+import { TextInputProps } from '../input-text/types';
+
+export type InputPasswordProps = Omit<
+  TextInputProps,
+  'type' | 'inputActionButton' | 'prefix' | 'suffix' | 'iconStart' | 'iconEnd'
+>;


### PR DESCRIPTION
## Description
- Add input password for HTML.
- Add associated missing documentation.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.