### PR TITLE
fix: add forward ref to input password

### DIFF
--- a/packages/react/ds/src/input-password/input-password.test.tsx
+++ b/packages/react/ds/src/input-password/input-password.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { renderComponent, cleanup, fireEvent } from '../test-utilities.js';
 import { InputPassword } from './input-password.js';
 
@@ -27,6 +28,16 @@ describe('InputPassword', () => {
 
     fireEvent.click(toggleButton);
     expect(inputElement).toHaveAttribute('type', 'password');
+  });
+
+  it('should support ref forwarding to the underlying input element', () => {
+    const ref = createRef<HTMLInputElement>();
+    const screen = renderComponent(
+      <InputPassword aria-label="Password Input" ref={ref} />,
+    );
+
+    const inputElement = screen.getByLabelText('Password Input');
+    expect(ref.current).toBe(inputElement);
   });
 
   it('should pass axe accessibility tests', async () => {

--- a/packages/react/ds/src/input-password/input-password.tsx
+++ b/packages/react/ds/src/input-password/input-password.tsx
@@ -1,34 +1,39 @@
 'use client';
-import { useState } from 'react';
+import React, { useState, forwardRef } from 'react';
 import { IconId } from '../icon/icon.js';
 import { InputText } from '../input-text/input-text.js';
 import { InputPasswordProps } from './types.js';
 
-export const InputPassword: React.FC<InputPasswordProps> = (props) => {
-  const [inputProps, setInputProps] = useState<{
-    type: 'password' | 'text';
-    icon: IconId;
-  }>({
-    icon: 'visibility',
-    type: 'password',
-  });
-
-  const handleOnClickVisibility = () => {
-    const isVisible = inputProps.type === 'text';
-    setInputProps({
-      type: isVisible ? 'password' : 'text',
-      icon: isVisible ? 'visibility' : 'visibility_off',
+export const InputPassword = forwardRef<HTMLInputElement, InputPasswordProps>(
+  (props, ref) => {
+    const [inputProps, setInputProps] = useState<{
+      type: 'password' | 'text';
+      icon: IconId;
+    }>({
+      icon: 'visibility',
+      type: 'password',
     });
-  };
 
-  return (
-    <InputText
-      {...props}
-      type={inputProps.type}
-      inputActionButton={{
-        icon: inputProps.icon,
-        onClick: handleOnClickVisibility,
-      }}
-    />
-  );
-};
+    const handleOnClickVisibility = () => {
+      const isVisible = inputProps.type === 'text';
+      setInputProps({
+        type: isVisible ? 'password' : 'text',
+        icon: isVisible ? 'visibility' : 'visibility_off',
+      });
+    };
+
+    return (
+      <InputText
+        {...props}
+        type={inputProps.type}
+        inputActionButton={{
+          icon: inputProps.icon,
+          onClick: handleOnClickVisibility,
+        }}
+        ref={ref}
+      />
+    );
+  },
+);
+
+InputPassword.displayName = 'InputPassword';


### PR DESCRIPTION
## Description
- Update input password react component with forward ref prop.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [X] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.