### PR TITLE
fix: Adding back classname in FormFieldBase

### DIFF
--- a/packages/react/ds/src/forms/form-field/form-field.tsx
+++ b/packages/react/ds/src/forms/form-field/form-field.tsx
@@ -35,7 +35,9 @@ function useFormFieldContext(component: string) {
 }
 
 function getSpecialComponentType(child: ReactNode): string | null {
-  if (!isValidElement(child)) return null;
+  if (!isValidElement(child)) {
+    return null;
+  }
 
   return (
     (child.type as any)?.componentType ||
@@ -61,7 +63,7 @@ const FormField = (props: FormFieldProps) => {
 
     return (
       <FormFieldContext.Provider value={true}>
-        <FormFieldBase>
+        <FormFieldBase className={props.className}>
           {props.label && <FormFieldLabel {...props.label} />}
           {props.hint && <FormFieldHint {...props.hint} />}
           {props.error && <FormFieldError {...props.error} />}
@@ -73,7 +75,9 @@ const FormField = (props: FormFieldProps) => {
 
   return (
     <FormFieldContext.Provider value={true}>
-      <FormFieldBase>{props.children}</FormFieldBase>
+      <FormFieldBase className={props.className}>
+        {props.children}
+      </FormFieldBase>
     </FormFieldContext.Provider>
   );
 };


### PR DESCRIPTION
## Description

Adding back classname in FormFieldBase

## Type of Issue

- [ ] 🚀 Feature
- [x] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).
