### PR TITLE
fix: update InputRadio, InputCheckbox, SelectNext and TextArea with controlled props

### DIFF
--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -1,7 +1,7 @@
-'use client';
-import NextLink from 'next/link';
-import { ComboBoxProps, CookieBannerProps } from '@/props';
-import { useForm, Controller } from 'react-hook-form';
+"use client";
+import NextLink from "next/link";
+import { ComboBoxProps, CookieBannerProps } from "@/props";
+import { useForm, Controller, FormProvider } from "react-hook-form";
 import {
   Alert,
   Autocomplete,
@@ -62,93 +62,419 @@ import {
   toaster,
   ToastProvider,
   ToastVariant,
-} from '@ogcio/design-system-react';
+} from "@ogcio/design-system-react";
 
 const headerProps: HeaderProps = {
   items: [
     {
-      label: 'Departments',
-      itemType: 'link',
-      href: '#',
-      showItemMode: 'desktop-only',
+      label: "Departments",
+      itemType: "link",
+      href: "#",
+      showItemMode: "desktop-only",
     },
     {
-      label: 'Services',
-      itemType: 'link',
-      href: '#',
-      showItemMode: 'desktop-only',
+      label: "Services",
+      itemType: "link",
+      href: "#",
+      showItemMode: "desktop-only",
     },
     {
-      itemType: 'divider',
-      showItemMode: 'desktop-only',
+      itemType: "divider",
+      showItemMode: "desktop-only",
     },
     {
-      label: 'Home',
-      icon: 'home',
-      itemType: 'link',
-      href: '/item1',
-      showItemMode: 'desktop-only',
+      label: "Home",
+      icon: "home",
+      itemType: "link",
+      href: "/item1",
+      showItemMode: "desktop-only",
     },
     {
-      label: 'Search',
-      icon: 'search',
-      itemType: 'slot',
+      label: "Search",
+      icon: "search",
+      itemType: "slot",
       component: <HeaderSearch />,
-      slotAppearance: 'dropdown',
-      showItemMode: 'desktop-only',
+      slotAppearance: "dropdown",
+      showItemMode: "desktop-only",
     },
   ],
   secondaryLinks: [
     {
-      href: '#',
-      label: 'English',
+      href: "#",
+      label: "English",
     },
     {
-      href: '#',
-      label: 'Gaeilge',
+      href: "#",
+      label: "Gaeilge",
     },
   ],
 };
 
 function MyForm() {
-  const { handleSubmit, control } = useForm({
+  const methods = useForm({
     defaultValues: {
-      myText: '',
+      myText: "",
+      inputText: "",
+      textArea: "",
+      selectOption: "",
     },
   });
 
+  const { handleSubmit, control, reset } = methods;
+
   const onSubmit = (data: any) => {
-    console.log('Form Data:', data);
+    console.log("Form Data:", data);
   };
 
+  const handleClear = () => {
+    reset();
+  };
+
+  const selectOptions: string[] = [
+    "Topic 1",
+    "Topic 2",
+    "Topic 3",
+    "Topic 4",
+    "Topic 5",
+    "Topic 6",
+    "Topic 7",
+    "Topic 8",
+    "Topic 9",
+    "Topic 10",
+    "Topic 11",
+    "Topic 12",
+    "Topic 13",
+    "Topic 14",
+    "Topic 15",
+    "Topic 16",
+    "Topic 17",
+    "Topic 18",
+    "Topic 19",
+    "Topic 20",
+    "Topic 21",
+    "Topic 22",
+    "Topic 23",
+    "Topic 24",
+    "Topic 25",
+    "Topic 26",
+    "Topic 27",
+    "Topic 28",
+    "Topic 29",
+    "Topic 30",
+    "Topic 31",
+    "Topic 32",
+    "Topic 33",
+    "Topic 34",
+    "Topic 35",
+    "Topic 36",
+    "Topic 37",
+    "Topic 38",
+    "Topic 39",
+    "Topic 40",
+    "Topic 41",
+    "Topic 42",
+    "Topic 43",
+    "Topic 44",
+    "Topic 45",
+    "Topic 46",
+    "Topic 47",
+    "Topic 48",
+    "Topic 49",
+    "Topic 50",
+    "Topic 51",
+    "Topic 52",
+    "Topic 53",
+    "Topic 54",
+    "Topic 55",
+    "Topic 56",
+    "Topic 57",
+    "Topic 58",
+    "Topic 59",
+    "Topic 60",
+    "Topic 61",
+    "Topic 62",
+    "Topic 63",
+    "Topic 64",
+    "Topic 65",
+    "Topic 66",
+    "Topic 67",
+    "Topic 68",
+    "Topic 69",
+    "Topic 70",
+    "Topic 71",
+    "Topic 72",
+    "Topic 73",
+    "Topic 74",
+    "Topic 75",
+    "Topic 76",
+    "Topic 77",
+    "Topic 78",
+    "Topic 79",
+    "Topic 80",
+    "Topic 81",
+    "Topic 82",
+    "Topic 83",
+    "Topic 84",
+    "Topic 85",
+    "Topic 86",
+    "Topic 87",
+    "Topic 88",
+    "Topic 89",
+    "Topic 90",
+    "Topic 91",
+    "Topic 92",
+    "Topic 93",
+    "Topic 94",
+    "Topic 95",
+    "Topic 96",
+    "Topic 97",
+    "Topic 98",
+    "Topic 99",
+    "Topic 100",
+    "Topic 101",
+    "Topic 102",
+    "Topic 103",
+    "Topic 104",
+    "Topic 105",
+    "Topic 106",
+    "Topic 107",
+    "Topic 108",
+    "Topic 109",
+    "Topic 110",
+    "Topic 111",
+    "Topic 112",
+    "Topic 113",
+    "Topic 114",
+    "Topic 115",
+    "Topic 116",
+    "Topic 117",
+    "Topic 118",
+    "Topic 119",
+    "Topic 120",
+    "Topic 121",
+    "Topic 122",
+    "Topic 123",
+    "Topic 124",
+    "Topic 125",
+    "Topic 126",
+    "Topic 127",
+    "Topic 128",
+    "Topic 129",
+    "Topic 130",
+    "Topic 131",
+    "Topic 132",
+    "Topic 133",
+    "Topic 134",
+    "Topic 135",
+    "Topic 136",
+    "Topic 137",
+    "Topic 138",
+    "Topic 139",
+    "Topic 140",
+    "Topic 141",
+    "Topic 142",
+    "Topic 143",
+    "Topic 144",
+    "Topic 145",
+    "Topic 146",
+    "Topic 147",
+    "Topic 148",
+    "Topic 149",
+    "Topic 150",
+    "Topic 151",
+    "Topic 152",
+    "Topic 153",
+    "Topic 154",
+    "Topic 155",
+    "Topic 156",
+    "Topic 157",
+    "Topic 158",
+    "Topic 159",
+    "Topic 160",
+    "Topic 161",
+    "Topic 162",
+    "Topic 163",
+    "Topic 164",
+    "Topic 165",
+    "Topic 166",
+    "Topic 167",
+    "Topic 168",
+    "Topic 169",
+    "Topic 170",
+    "Topic 171",
+    "Topic 172",
+    "Topic 173",
+    "Topic 174",
+    "Topic 175",
+    "Topic 176",
+    "Topic 177",
+    "Topic 178",
+    "Topic 179",
+    "Topic 180",
+    "Topic 181",
+    "Topic 182",
+    "Topic 183",
+    "Topic 184",
+    "Topic 185",
+    "Topic 186",
+    "Topic 187",
+    "Topic 188",
+    "Topic 189",
+    "Topic 190",
+    "Topic 191",
+    "Topic 192",
+    "Topic 193",
+    "Topic 194",
+    "Topic 195",
+    "Topic 196",
+    "Topic 197",
+    "Topic 198",
+    "Topic 199",
+    "Topic 200",
+  ];
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <Controller
-        name="myText"
-        control={control}
-        rules={{ maxLength: 50 }}
-        render={({ field, fieldState }) => (
-          <>
-            <TextArea id="textarea-id" maxChars={50} {...field} />
-          </>
-        )}
-      />
-    </form>
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Container
+          className="
+            p-0
+            w-full
+            border
+            border-[--gieds-color-gray-200]
+            bg-white
+            rounded-lg
+            shadow-lg
+          "
+          id="card-container"
+        >
+          <Container className="px-4 pt-4 pb-0 md:px-8 md:pt-8 md:pb-6">
+            <Container className="p-0 pb-2">
+              <Heading as="h3" id="heading">
+                My Form
+              </Heading>
+            </Container>
+
+            <Container className="p-0 pb-8">
+              <Heading
+                as="h5"
+                className="font-normal text-[--gieds-color-gray-600]"
+                id="subheading"
+              >
+                Please fill in the fields
+              </Heading>
+            </Container>
+
+            <Container className="flex flex-col items-center p-0 gap-4 w-full lg:w-[480px] mx-auto">
+              <FormField
+                className="
+                  w-full
+                  font-[family-name:var(--gieds-font-family-primary)]
+                "
+                label={{ text: "Input Text" }}
+              >
+                <Controller
+                  control={control}
+                  name="inputText"
+                  render={({ field }) => (
+                    <InputText
+                      {...field}
+                      data-testid="input-text-id"
+                      id="input-text-id"
+                      className="w-full"
+                    />
+                  )}
+                />
+              </FormField>
+              <FormField
+                className="
+                  w-full
+                  font-[family-name:var(--gieds-font-family-primary)]
+                "
+                label={{ text: "Text Area" }}
+              >
+                <Controller
+                  control={control}
+                  name="textArea"
+                  render={({ field }) => (
+                    <TextArea
+                      {...field}
+                      cols={100}
+                      rows={4}
+                      id="textarea-id-0"
+                      data-testid="textarea-id-0"
+                      className="w-full"
+                      maxChars={100}
+                    />
+                  )}
+                />
+              </FormField>
+              <FormField
+                className="
+                  w-full
+                  font-[family-name:var(--gieds-font-family-primary)]
+                "
+                label={{ text: "Select an Option" }}
+              >
+                <Controller
+                  control={control}
+                  name="selectOption"
+                  render={({ field }) => (
+                    <SelectNext
+                      {...field}
+                      enableSearch
+                      id="select-option-id"
+                      data-testid="select-option-id"
+                      className="w-full"
+                      onChange={(value: any) => field.onChange(value)}
+                    >
+                      <SelectItemNext value="">Please select</SelectItemNext>
+                      {selectOptions.map((opt) => (
+                        <SelectItemNext key={opt} value={opt}>
+                          {opt}
+                        </SelectItemNext>
+                      ))}
+                    </SelectNext>
+                  )}
+                />
+              </FormField>
+              <Container className="flex gap-2">
+                <Button
+                  type="submit"
+                  data-testid="submit-button"
+                  variant="primary"
+                >
+                  Submit
+                </Button>
+                <Button
+                  type="button"
+                  data-testid="clear-button"
+                  variant="secondary"
+                  onClick={handleClear}
+                >
+                  Clear
+                </Button>
+              </Container>
+            </Container>
+          </Container>
+        </Container>
+      </form>
+    </FormProvider>
   );
 }
 
 const handleCreateToast = (
   title: string,
   variant: ToastVariant,
-  slotAction?: any,
+  slotAction?: any
 ) =>
   toaster.create({
     title,
     variant,
-    description: 'This is a toast notification.',
+    description: "This is a toast notification.",
     position: {
-      x: 'right',
-      y: 'bottom',
+      x: "right",
+      y: "bottom",
     },
     duration: 3000,
     dismissible: true,
@@ -160,7 +486,7 @@ export default function Home() {
     <>
       {/* TODO: Investigate the issue regarding the Header component when running the application */}
       <Header
-        logo={{ href: '/' }}
+        logo={{ href: "/" }}
         items={headerProps.items}
         addDefaultMobileMenu
         secondaryLinks={headerProps.secondaryLinks}
@@ -185,28 +511,28 @@ export default function Home() {
           <SelectItemNext value="Option2">Option 2</SelectItemNext>
         </SelectNext>
         <br />
-        <Button onClick={() => handleCreateToast('Success', 'success')}>
+        <Button onClick={() => handleCreateToast("Success", "success")}>
           Trigger Success Toast via callback
         </Button>
         <br />
-        <Button onClick={() => handleCreateToast('Error', 'danger')}>
+        <Button onClick={() => handleCreateToast("Error", "danger")}>
           Trigger Danger Toast via callback
         </Button>
         <br />
-        <Button onClick={() => handleCreateToast('Info', 'info')}>
+        <Button onClick={() => handleCreateToast("Info", "info")}>
           Trigger Info Toast via callback
         </Button>
         <br />
-        <Button onClick={() => handleCreateToast('Warning', 'warning')}>
+        <Button onClick={() => handleCreateToast("Warning", "warning")}>
           Trigger Warning Toast via callback
         </Button>
         <br />
         <Button
           onClick={() =>
             handleCreateToast(
-              'Success',
-              'success',
-              <NextLink href="#">Custom Nextjs Link</NextLink>,
+              "Success",
+              "success",
+              <NextLink href="#">Custom Nextjs Link</NextLink>
             )
           }
         >
@@ -236,25 +562,25 @@ export default function Home() {
           <h2>Card</h2>
           <Card
             action={{
-              children: 'Button',
-              type: 'button',
-              variant: 'secondary',
+              children: "Button",
+              type: "button",
+              variant: "secondary",
             }}
             content="Lorem ipsum dolor sit amet consectetur. Lectus aliquam morbi purus ac. Sollicitudin."
             href="#"
             inset="none"
             media={{
               config: {
-                alt: 'Card Title',
-                aspectRatio: '4 / 3',
-                src: 'https://placeholderjs.com/400x300',
+                alt: "Card Title",
+                aspectRatio: "4 / 3",
+                src: "https://placeholderjs.com/400x300",
               },
-              type: 'image',
+              type: "image",
             }}
             subTitle="Subheading"
             tag={{
-              text: 'New',
-              type: 'info',
+              text: "New",
+              type: "info",
             }}
             title="Card Title"
             type="horizontal"
@@ -262,10 +588,10 @@ export default function Home() {
           <h2>Card with Nextjs Link</h2>
           <Card
             action={{
-              children: 'Learn More',
-              href: '#',
-              size: 'md',
-              type: 'link',
+              children: "Learn More",
+              href: "#",
+              size: "md",
+              type: "link",
             }}
             content="Lorem ipsum dolor sit amet consectetur. Lectus aliquam morbi purus ac. Sollicitudin."
             title="Vertical Card Without Image"
@@ -287,8 +613,8 @@ export default function Home() {
           <Icon icon="thumb_up" />
           <IconButton
             icon={{
-              icon: 'send',
-              ariaLabel: 'Send',
+              icon: "send",
+              ariaLabel: "Send",
             }}
           />
           <Form>
@@ -340,7 +666,7 @@ export default function Home() {
           </FormField>
           <FormField>
             <FormFieldLabel htmlFor="textarea-id">
-              Textarea with React Hook Form
+              Inputs with React Hook Form
             </FormFieldLabel>
             <FormFieldHint>Hint: This is a helpful hint.</FormFieldHint>
             <MyForm />
@@ -352,7 +678,6 @@ export default function Home() {
             <FormFieldHint>Hint: This is a helpful hint.</FormFieldHint>
             <TextArea id="textarea-id2" maxChars={50} />
           </FormField>
-
           <span className="material-symbols-outlined">face</span>
           <div>
             <Modal triggerButton={<Button>Open Modal</Button>}>
@@ -396,11 +721,11 @@ export default function Home() {
             </Drawer>
           </div>
 
-          <List items={['Item 1', 'Item 2', 'Item 3']} type={'bullet'} />
+          <List items={["Item 1", "Item 2", "Item 3"]} type={"bullet"} />
           <Chip label="Chip" onClose={() => null} />
           <div className="gi-h-[300px] gi-bg-gray-50 gi-overflow-auto gi-p-2">
             <Stack
-              direction={{ sm: 'column', base: 'row' }}
+              direction={{ sm: "column", base: "row" }}
               itemsAlignment="start"
               itemsDistribution="start"
               gap={5}

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -121,21 +121,23 @@ function MyForm() {
       textArea: "",
       selectOption: "",
       legacySelect: "select-option",
-      city: "",
       password: "",
       radioGroup: "",
-      role: "",
+      checkboxGroup: [],
     },
   });
 
   const { handleSubmit, control, reset } = methods;
 
   const onSubmit = (data: any) => {
+    console.log("Form submitted successfully");
     console.log("Form Data:", data);
   };
 
   const handleClear = () => {
     reset();
+    console.log("Form cleared");
+    console.log("Form Data after clear:", methods.getValues());
   };
 
   const selectOptions: string[] = [
@@ -246,6 +248,7 @@ function MyForm() {
                 />
               </FormField>
 
+              {/* Radio Group */}
               <FormField label={{ text: "Radio Group" }} className="w-full">
                 <Controller
                   name="radioGroup"
@@ -260,6 +263,44 @@ function MyForm() {
                       <InputRadio value="option2" label="Option 2" />
                       <InputRadio value="option3" label="Option 3" />
                     </InputRadioGroup>
+                  )}
+                />
+              </FormField>
+
+              {/* Checkbox */}
+              <FormField>
+                <FormFieldLabel>Organisation</FormFieldLabel>
+                <Controller
+                  name="checkboxGroup"
+                  control={control}
+                  render={({ field }) => (
+                    <InputCheckboxGroup
+                      groupId="UniqueID"
+                      values={field.value}
+                      onChange={field.onChange}
+                    >
+                      <InputCheckbox
+                        id="UniqueID-check1"
+                        label="Employment Tribunal"
+                        value="employment-tribunal"
+                      />
+                      <InputCheckbox
+                        id="UniqueID-check2"
+                        label="Ministry of Defence"
+                        value="ministry-of-defence"
+                      />
+                      <InputCheckbox
+                        id="UniqueID-check3"
+                        label="Department for Transport"
+                        value="department-for-transport"
+                      />
+                      <InputCheckbox
+                        disabled
+                        id="UniqueID-check4"
+                        label="Others"
+                        value="others"
+                      />
+                    </InputCheckboxGroup>
                   )}
                 />
               </FormField>

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -11,6 +11,8 @@ import {
   BreadcrumbLink,
   Breadcrumbs,
   Button,
+  ButtonGroup,
+  ButtonGroupItem,
   Card,
   Chip,
   Combobox,
@@ -123,6 +125,7 @@ function MyForm() {
       legacySelect: "select-option",
       password: "",
       radioGroup: "",
+      buttonGroup: "",
       checkboxGroup: [],
     },
   });
@@ -263,6 +266,26 @@ function MyForm() {
                       <InputRadio value="option2" label="Option 2" />
                       <InputRadio value="option3" label="Option 3" />
                     </InputRadioGroup>
+                  )}
+                />
+              </FormField>
+
+              {/* Button Group */}
+              <FormField label={{ text: "Button Group" }} className="w-full">
+                <FormFieldLabel>Are you currently a customer?</FormFieldLabel>
+                <Controller
+                  name="buttonGroup"
+                  control={control}
+                  render={({ field }) => (
+                    <ButtonGroup
+                      value={field.value}
+                      name="customer-status"
+                      size="medium"
+                      onChange={field.onChange}
+                    >
+                      <ButtonGroupItem value="yes">Yes</ButtonGroupItem>
+                      <ButtonGroupItem value="no">No</ButtonGroupItem>
+                    </ButtonGroup>
                   )}
                 />
               </FormField>

--- a/examples/nextjs/src/app/page.tsx
+++ b/examples/nextjs/src/app/page.tsx
@@ -35,6 +35,7 @@ import {
   IconButton,
   InputCheckbox,
   InputCheckboxGroup,
+  InputFile,
   InputPassword,
   InputRadio,
   InputRadioGroup,
@@ -50,6 +51,8 @@ import {
   PhaseBanner,
   ProgressBar,
   ProgressStepper,
+  Select,
+  SelectItem,
   SelectItemNext,
   SelectNext,
   Stack,
@@ -117,6 +120,11 @@ function MyForm() {
       inputText: "",
       textArea: "",
       selectOption: "",
+      legacySelect: "select-option",
+      city: "",
+      password: "",
+      radioGroup: "",
+      role: "",
     },
   });
 
@@ -136,216 +144,13 @@ function MyForm() {
     "Topic 3",
     "Topic 4",
     "Topic 5",
-    "Topic 6",
-    "Topic 7",
-    "Topic 8",
-    "Topic 9",
-    "Topic 10",
-    "Topic 11",
-    "Topic 12",
-    "Topic 13",
-    "Topic 14",
-    "Topic 15",
-    "Topic 16",
-    "Topic 17",
-    "Topic 18",
-    "Topic 19",
-    "Topic 20",
-    "Topic 21",
-    "Topic 22",
-    "Topic 23",
-    "Topic 24",
-    "Topic 25",
-    "Topic 26",
-    "Topic 27",
-    "Topic 28",
-    "Topic 29",
-    "Topic 30",
-    "Topic 31",
-    "Topic 32",
-    "Topic 33",
-    "Topic 34",
-    "Topic 35",
-    "Topic 36",
-    "Topic 37",
-    "Topic 38",
-    "Topic 39",
-    "Topic 40",
-    "Topic 41",
-    "Topic 42",
-    "Topic 43",
-    "Topic 44",
-    "Topic 45",
-    "Topic 46",
-    "Topic 47",
-    "Topic 48",
-    "Topic 49",
-    "Topic 50",
-    "Topic 51",
-    "Topic 52",
-    "Topic 53",
-    "Topic 54",
-    "Topic 55",
-    "Topic 56",
-    "Topic 57",
-    "Topic 58",
-    "Topic 59",
-    "Topic 60",
-    "Topic 61",
-    "Topic 62",
-    "Topic 63",
-    "Topic 64",
-    "Topic 65",
-    "Topic 66",
-    "Topic 67",
-    "Topic 68",
-    "Topic 69",
-    "Topic 70",
-    "Topic 71",
-    "Topic 72",
-    "Topic 73",
-    "Topic 74",
-    "Topic 75",
-    "Topic 76",
-    "Topic 77",
-    "Topic 78",
-    "Topic 79",
-    "Topic 80",
-    "Topic 81",
-    "Topic 82",
-    "Topic 83",
-    "Topic 84",
-    "Topic 85",
-    "Topic 86",
-    "Topic 87",
-    "Topic 88",
-    "Topic 89",
-    "Topic 90",
-    "Topic 91",
-    "Topic 92",
-    "Topic 93",
-    "Topic 94",
-    "Topic 95",
-    "Topic 96",
-    "Topic 97",
-    "Topic 98",
-    "Topic 99",
-    "Topic 100",
-    "Topic 101",
-    "Topic 102",
-    "Topic 103",
-    "Topic 104",
-    "Topic 105",
-    "Topic 106",
-    "Topic 107",
-    "Topic 108",
-    "Topic 109",
-    "Topic 110",
-    "Topic 111",
-    "Topic 112",
-    "Topic 113",
-    "Topic 114",
-    "Topic 115",
-    "Topic 116",
-    "Topic 117",
-    "Topic 118",
-    "Topic 119",
-    "Topic 120",
-    "Topic 121",
-    "Topic 122",
-    "Topic 123",
-    "Topic 124",
-    "Topic 125",
-    "Topic 126",
-    "Topic 127",
-    "Topic 128",
-    "Topic 129",
-    "Topic 130",
-    "Topic 131",
-    "Topic 132",
-    "Topic 133",
-    "Topic 134",
-    "Topic 135",
-    "Topic 136",
-    "Topic 137",
-    "Topic 138",
-    "Topic 139",
-    "Topic 140",
-    "Topic 141",
-    "Topic 142",
-    "Topic 143",
-    "Topic 144",
-    "Topic 145",
-    "Topic 146",
-    "Topic 147",
-    "Topic 148",
-    "Topic 149",
-    "Topic 150",
-    "Topic 151",
-    "Topic 152",
-    "Topic 153",
-    "Topic 154",
-    "Topic 155",
-    "Topic 156",
-    "Topic 157",
-    "Topic 158",
-    "Topic 159",
-    "Topic 160",
-    "Topic 161",
-    "Topic 162",
-    "Topic 163",
-    "Topic 164",
-    "Topic 165",
-    "Topic 166",
-    "Topic 167",
-    "Topic 168",
-    "Topic 169",
-    "Topic 170",
-    "Topic 171",
-    "Topic 172",
-    "Topic 173",
-    "Topic 174",
-    "Topic 175",
-    "Topic 176",
-    "Topic 177",
-    "Topic 178",
-    "Topic 179",
-    "Topic 180",
-    "Topic 181",
-    "Topic 182",
-    "Topic 183",
-    "Topic 184",
-    "Topic 185",
-    "Topic 186",
-    "Topic 187",
-    "Topic 188",
-    "Topic 189",
-    "Topic 190",
-    "Topic 191",
-    "Topic 192",
-    "Topic 193",
-    "Topic 194",
-    "Topic 195",
-    "Topic 196",
-    "Topic 197",
-    "Topic 198",
-    "Topic 199",
-    "Topic 200",
   ];
 
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Container
-          className="
-            p-0
-            w-full
-            border
-            border-[--gieds-color-gray-200]
-            bg-white
-            rounded-lg
-            shadow-lg
-          "
+          className="p-0 w-full border border-[--gieds-color-gray-200] bg-white rounded-lg shadow-lg"
           id="card-container"
         >
           <Container className="px-4 pt-4 pb-0 md:px-8 md:pt-8 md:pb-6">
@@ -366,33 +171,23 @@ function MyForm() {
             </Container>
 
             <Container className="flex flex-col items-center p-0 gap-4 w-full lg:w-[480px] mx-auto">
-              <FormField
-                className="
-                  w-full
-                  font-[family-name:var(--gieds-font-family-primary)]
-                "
-                label={{ text: "Input Text" }}
-              >
+              {/* Input Text */}
+              <FormField label={{ text: "Input Text" }} className="w-full">
                 <Controller
                   control={control}
                   name="inputText"
                   render={({ field }) => (
                     <InputText
                       {...field}
-                      data-testid="input-text-id"
                       id="input-text-id"
                       className="w-full"
                     />
                   )}
                 />
               </FormField>
-              <FormField
-                className="
-                  w-full
-                  font-[family-name:var(--gieds-font-family-primary)]
-                "
-                label={{ text: "Text Area" }}
-              >
+
+              {/* Text Area */}
+              <FormField label={{ text: "Text Area" }} className="w-full">
                 <Controller
                   control={control}
                   name="textArea"
@@ -402,20 +197,15 @@ function MyForm() {
                       cols={100}
                       rows={4}
                       id="textarea-id-0"
-                      data-testid="textarea-id-0"
                       className="w-full"
                       maxChars={100}
                     />
                   )}
                 />
               </FormField>
-              <FormField
-                className="
-                  w-full
-                  font-[family-name:var(--gieds-font-family-primary)]
-                "
-                label={{ text: "Select an Option" }}
-              >
+
+              {/* SelectNext */}
+              <FormField label={{ text: "SelectNext" }} className="w-full">
                 <Controller
                   control={control}
                   name="selectOption"
@@ -424,7 +214,6 @@ function MyForm() {
                       {...field}
                       enableSearch
                       id="select-option-id"
-                      data-testid="select-option-id"
                       className="w-full"
                       onChange={(value: any) => field.onChange(value)}
                     >
@@ -438,20 +227,60 @@ function MyForm() {
                   )}
                 />
               </FormField>
+
+              {/* Legacy Select */}
+              <FormField label={{ text: "Select" }} className="w-full">
+                <Controller
+                  control={control}
+                  name="legacySelect"
+                  render={({ field }) => (
+                    <Select {...field} aria-label="Select">
+                      <SelectItem value="select-option" hidden>
+                        Select Option
+                      </SelectItem>
+                      <SelectItem value="value-1">Option 1</SelectItem>
+                      <SelectItem value="value-2">Option 2</SelectItem>
+                      <SelectItem value="value-3">Option 3</SelectItem>
+                    </Select>
+                  )}
+                />
+              </FormField>
+
+              <FormField label={{ text: "Radio Group" }} className="w-full">
+                <Controller
+                  name="radioGroup"
+                  control={control}
+                  render={({ field }) => (
+                    <InputRadioGroup
+                      groupId="my-radio-group"
+                      value={field.value}
+                      onChange={field.onChange}
+                    >
+                      <InputRadio value="option1" label="Option 1" />
+                      <InputRadio value="option2" label="Option 2" />
+                      <InputRadio value="option3" label="Option 3" />
+                    </InputRadioGroup>
+                  )}
+                />
+              </FormField>
+
+              {/* Password */}
+              <FormField label={{ text: "Password" }} className="w-full">
+                <Controller
+                  control={control}
+                  name="password"
+                  render={({ field }) => (
+                    <InputPassword {...field} placeholder="Placeholder" />
+                  )}
+                />
+              </FormField>
+
+              {/* Buttons */}
               <Container className="flex gap-2">
-                <Button
-                  type="submit"
-                  data-testid="submit-button"
-                  variant="primary"
-                >
+                <Button type="submit" variant="primary">
                   Submit
                 </Button>
-                <Button
-                  type="button"
-                  data-testid="clear-button"
-                  variant="secondary"
-                  onClick={handleClear}
-                >
+                <Button type="button" variant="secondary" onClick={handleClear}>
                   Clear
                 </Button>
               </Container>

--- a/packages/react/ds/src/button-group/button-group.stories.tsx
+++ b/packages/react/ds/src/button-group/button-group.stories.tsx
@@ -5,6 +5,8 @@ import {
   FormFieldLabel,
 } from '../forms/form-field/form-field.js';
 import { ButtonGroup, ButtonGroupItem } from './button-group.js';
+import { userEvent, waitFor, within, expect } from '@storybook/test';
+import { useState } from 'react';
 
 const meta = {
   title: 'Form/ButtonGroup',
@@ -143,5 +145,64 @@ export const ExplicitItems: Story = {
     name: 'customer-status',
     size: 'medium',
     defaultValue: 'no',
+  },
+};
+
+export const Controlled: Story = {
+  name: 'Yes/No Question (Controlled)',
+  render: (arguments_) => {
+    const [value, setValue] = useState(
+      arguments_.value || arguments_.defaultValue,
+    );
+
+    const handleChange = (newValue: string) => {
+      setValue(newValue);
+      arguments_.onChange?.(newValue);
+      console.log('Value changed to:', newValue);
+    };
+
+    return (
+      <FormField>
+        <FormFieldLabel>Are you currently a customer?</FormFieldLabel>
+        <ButtonGroup
+          name={arguments_.name}
+          size={arguments_.size}
+          value={value}
+          onChange={handleChange}
+        >
+          <ButtonGroupItem value="yes">Yes</ButtonGroupItem>
+          <ButtonGroupItem value="no">No</ButtonGroupItem>
+        </ButtonGroup>
+      </FormField>
+    );
+  },
+
+  args: {
+    name: 'customer-status',
+    size: 'medium',
+    value: 'no',
+    defaultValue: 'no',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This story demonstrates the ButtonGroup component in controlled mode. The component's value is managed by React state, making it suitable for use with form libraries like React Hook Form.",
+        language: 'tsx',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const yesButton = await canvas.getByText('Yes');
+    const noButton = await canvas.getByText('No');
+
+    await userEvent.click(yesButton);
+
+    await waitFor(() => {
+      expect(yesButton).toBeChecked();
+      expect(noButton).not.toBeChecked();
+    });
   },
 };

--- a/packages/react/ds/src/button-group/button-group.test.tsx
+++ b/packages/react/ds/src/button-group/button-group.test.tsx
@@ -23,6 +23,7 @@ describe('buttonGroup', () => {
     expect(buttonTwoElement).not.toHaveClass('gi-btn-primary-dark');
     expect(buttonTwoElement).toHaveAttribute('aria-checked', 'false');
   });
+
   it('should not submit the form on press a button group items', async () => {
     const onSubmitSpy = vi.fn();
     const user = userEvent.setup();

--- a/packages/react/ds/src/button-group/button-group.tsx
+++ b/packages/react/ds/src/button-group/button-group.tsx
@@ -5,6 +5,7 @@ import {
   PropsWithChildren,
   useContext,
   useState,
+  useEffect,
 } from 'react';
 import { Button } from '../button/button.js';
 import { ButtonAppearance, ButtonSize } from '../button/types.js';
@@ -84,6 +85,7 @@ type ButtonGroupProps = PropsWithChildren<{
   appearance?: ButtonAppearance;
   onChange?: (value: string) => void;
   defaultValue?: string;
+  value?: string;
   role?: string;
   'aria-labelledby'?: string;
   'aria-describedby'?: string;
@@ -95,14 +97,31 @@ export const ButtonGroup: FC<ButtonGroupProps> = ({
   appearance = 'dark',
   onChange,
   defaultValue,
+  value,
   children,
   role: customRole,
   'aria-labelledby': ariaLabelledby,
   'aria-describedby': ariaDescribedby,
 }) => {
-  const [selectedValue, setSelectedValue] = useState<string | undefined>(
+  const [internalValue, setInternalValue] = useState<string | undefined>(
     defaultValue,
   );
+
+  const selectedValue = value !== undefined ? value : internalValue;
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setInternalValue(value);
+    }
+  }, [value]);
+
+  const setSelectedValue = (newValue: string) => {
+    // Only update internal state if not controlled
+    if (value === undefined) {
+      setInternalValue(newValue);
+    }
+    onChange?.(newValue);
+  };
 
   const groupId = useDomId();
 

--- a/packages/react/ds/src/input-checkbox-group/input-checkbox-group.stories.tsx
+++ b/packages/react/ds/src/input-checkbox-group/input-checkbox-group.stories.tsx
@@ -7,6 +7,8 @@ import {
 } from '../forms/form-field/form-field.js';
 import { InputCheckbox } from '../input-checkbox/input-checkbox.js';
 import { InputCheckboxGroup } from './input-checkbox-group.js';
+import { userEvent, waitFor, within, expect } from '@storybook/test';
+import React from 'react';
 
 const meta = {
   title: 'Form/Checkbox/InputCheckboxGroup',
@@ -100,4 +102,64 @@ export const WithLabelHintAndError: Story = {
       </InputCheckboxGroup>
     </FormField>
   ),
+};
+
+export const Controlled: Story = {
+  args: {
+    groupId: 'controlled-checkbox-group',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This story demonstrates a controlled input checkbox group where users can select multiple hobbies. The selected values are managed in the component's state, allowing for dynamic updates as checkboxes are checked or unchecked.",
+      },
+    },
+  },
+  render: (props) => {
+    const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
+
+    return (
+      <FormField>
+        <FormFieldLabel>Select your hobbies</FormFieldLabel>
+        <InputCheckboxGroup
+          {...props}
+          values={selectedValues}
+          onChange={setSelectedValues}
+        >
+          <InputCheckbox
+            value="reading"
+            label="Reading"
+            id="controlled-check1"
+            checked={selectedValues.includes('reading')}
+          />
+          <InputCheckbox
+            value="traveling"
+            label="Traveling"
+            id="controlled-check2"
+            checked={selectedValues.includes('traveling')}
+          />
+          <InputCheckbox
+            value="gaming"
+            label="Gaming"
+            id="controlled-check3"
+            checked={selectedValues.includes('gaming')}
+          />
+        </InputCheckboxGroup>
+      </FormField>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const readingCheckbox = await canvas.getByLabelText('Reading');
+    const travelingCheckbox = await canvas.getByLabelText('Traveling');
+
+    await userEvent.click(readingCheckbox);
+    await userEvent.click(travelingCheckbox);
+
+    await waitFor(() => {
+      expect(readingCheckbox).toBeChecked();
+      expect(travelingCheckbox).toBeChecked();
+    });
+  },
 };

--- a/packages/react/ds/src/input-checkbox-group/input-checkbox-group.tsx
+++ b/packages/react/ds/src/input-checkbox-group/input-checkbox-group.tsx
@@ -1,22 +1,42 @@
 'use client';
-import { Children, cloneElement, isValidElement, useState } from 'react';
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useState,
+  useEffect,
+} from 'react';
 import { InputCheckboxSizeEnumType } from '../input-checkbox/types.js';
 import { InputRadioSizeType } from '../input-radio/types.js';
 import { InputCheckboxGroupProps } from './types.js';
 
 export const InputCheckboxGroup: React.FC<
   React.PropsWithChildren<InputCheckboxGroupProps>
-> = ({ size, groupId, inline, onChange, children }) => {
-  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+> = ({ size, groupId, inline, onChange, children, values: externalValues }) => {
+  const [internalValues, setInternalValues] = useState<string[]>(
+    externalValues || [],
+  );
+
+  // Sync internal state with external value (for React Hook Form reset)
+  useEffect(() => {
+    setInternalValues(externalValues || []);
+  }, [externalValues]);
+
+  const currentValues =
+    externalValues !== undefined ? externalValues : internalValues;
 
   const handleCheckboxChange = (value: string) => {
     let newValues = [];
 
-    newValues = selectedValues.includes(value)
-      ? selectedValues.filter((selectedValue) => selectedValue !== value)
-      : [...selectedValues, value];
+    newValues = currentValues.includes(value)
+      ? currentValues.filter((selectedValue) => selectedValue !== value)
+      : [...currentValues, value];
 
-    setSelectedValues(newValues);
+    // Only update internal state if not controlled
+    if (externalValues === undefined) {
+      setInternalValues(newValues);
+    }
+
     onChange?.(newValues);
   };
 
@@ -38,13 +58,14 @@ export const InputCheckboxGroup: React.FC<
         name: string;
       }>(element, {
         onChange: () => handleCheckboxChange(element.props.value),
-        checked: selectedValues.includes(element.props.value),
+        checked: currentValues.includes(element.props.value),
         size,
         name: groupId,
       });
     }
     return element;
   });
+
   return (
     <div className="gi-input-group-container">
       <div className="gi-input-group-options-container">

--- a/packages/react/ds/src/input-checkbox-group/types.ts
+++ b/packages/react/ds/src/input-checkbox-group/types.ts
@@ -4,5 +4,6 @@ export type InputCheckboxGroupProps = {
   size?: InputCheckboxSizeEnumType;
   groupId: string;
   inline?: boolean;
+  values?: string[];
   onChange?: (items: string[]) => void;
 };

--- a/packages/react/ds/src/input-radio-group/input-radio-group.stories.tsx
+++ b/packages/react/ds/src/input-radio-group/input-radio-group.stories.tsx
@@ -8,6 +8,8 @@ import {
 import { InputRadio } from '../input-radio/input-radio.js';
 import { InputRadioGroup } from '../input-radio-group/input-radio-group.js';
 import { Paragraph } from '../paragraph/paragraph.js';
+import React from 'react';
+import { userEvent, waitFor, within, expect } from '@storybook/test';
 
 const meta = {
   title: 'Form/Radio/InputRadioGroup',
@@ -35,6 +37,7 @@ export const Default: Story = {
   args: {
     groupId: 'city',
   },
+
   render: (arguments_) => (
     <FormField>
       <FormFieldLabel>Where do you live?</FormFieldLabel>
@@ -45,6 +48,33 @@ export const Default: Story = {
       </InputRadioGroup>
     </FormField>
   ),
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dublinOption = await canvas.getByLabelText('Dublin');
+    const corkOption = await canvas.getByLabelText('Cork');
+    const galwayOption = await canvas.getByLabelText('Galway');
+
+    await userEvent.click(dublinOption);
+    await waitFor(() => {
+      expect(dublinOption).toBeChecked();
+      expect(corkOption).not.toBeChecked();
+      expect(galwayOption).not.toBeChecked();
+    });
+
+    await userEvent.click(corkOption);
+    await waitFor(() => {
+      expect(corkOption).toBeChecked();
+      expect(dublinOption).not.toBeChecked();
+      expect(galwayOption).not.toBeChecked();
+    });
+
+    await userEvent.click(galwayOption);
+    await waitFor(() => {
+      expect(galwayOption).toBeChecked();
+      expect(dublinOption).not.toBeChecked();
+      expect(corkOption).not.toBeChecked();
+    });
+  },
 };
 
 export const Inline: Story = {
@@ -165,4 +195,54 @@ export const WithConditionalInput: Story = {
       </InputRadioGroup>
     </FormField>
   ),
+};
+
+export const Controlled: Story = {
+  args: {
+    groupId: 'controlled',
+  },
+  render: (arguments_) => {
+    const [selectedValue, setSelectedValue] = React.useState<
+      string | undefined
+    >(undefined);
+
+    const handleChange = (event?: React.ChangeEvent<HTMLInputElement>) => {
+      if (event) {
+        setSelectedValue(event.target.value);
+      }
+    };
+
+    return (
+      <FormField>
+        <FormFieldLabel>Choose an option</FormFieldLabel>
+        <InputRadioGroup
+          {...arguments_}
+          value={selectedValue}
+          onChange={handleChange}
+        >
+          <InputRadio value="option1" label="Option 1" />
+          <InputRadio value="option2" label="Option 2" />
+          <InputRadio value="option3" label="Option 3" />
+        </InputRadioGroup>
+      </FormField>
+    );
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const option1 = await canvas.getByLabelText('Option 1');
+    const option2 = await canvas.getByLabelText('Option 2');
+
+    await userEvent.click(option1);
+
+    await waitFor(() => {
+      expect(option1).toBeChecked();
+      expect(option2).not.toBeChecked();
+    });
+
+    await userEvent.click(option2);
+    await waitFor(() => {
+      expect(option2).toBeChecked();
+      expect(option1).not.toBeChecked();
+    });
+  },
 };

--- a/packages/react/ds/src/input-radio-group/input-radio-group.stories.tsx
+++ b/packages/react/ds/src/input-radio-group/input-radio-group.stories.tsx
@@ -201,6 +201,14 @@ export const Controlled: Story = {
   args: {
     groupId: 'controlled',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This story demonstrates a controlled input radio group where users can select option. The selected value are managed in the component's state, allowing for dynamic updates as radios are selected or unselected.",
+      },
+    },
+  },
   render: (arguments_) => {
     const [selectedValue, setSelectedValue] = React.useState<
       string | undefined

--- a/packages/react/ds/src/input-radio-group/input-radio-group.tsx
+++ b/packages/react/ds/src/input-radio-group/input-radio-group.tsx
@@ -8,6 +8,7 @@ import {
   isValidElement,
   PropsWithChildren,
   useState,
+  useEffect,
 } from 'react';
 import { InputRadioGroupProps } from './types.js';
 
@@ -15,12 +16,26 @@ export const InputRadioGroup: FC<PropsWithChildren<InputRadioGroupProps>> = ({
   groupId,
   inline,
   onChange,
+  value: externalValue,
   children,
 }) => {
-  const [value, setValue] = useState<null | string>();
+  const [internalValue, setInternalValue] = useState<null | string>(
+    externalValue || null,
+  );
+
+  // Sync internal state with external value (for React Hook Form reset)
+  useEffect(() => {
+    setInternalValue(externalValue || null);
+  }, [externalValue]);
+
+  const currentValue =
+    externalValue !== undefined ? externalValue : internalValue;
 
   const onOptionChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value);
+    // We only update internal state if not controlled
+    if (externalValue === undefined) {
+      setInternalValue(event.target.value);
+    }
     onChange?.(event);
   };
 
@@ -40,12 +55,13 @@ export const InputRadioGroup: FC<PropsWithChildren<InputRadioGroupProps>> = ({
         name: string;
       }>(element, {
         onChange: onOptionChange,
-        checked: value === element.props.value,
+        checked: currentValue === element.props.value,
         name: groupId,
       });
     }
     return element;
   });
+
   return (
     <div className="gi-input-group-container">
       <div className="gi-input-group-options-container">

--- a/packages/react/ds/src/input-radio-group/types.ts
+++ b/packages/react/ds/src/input-radio-group/types.ts
@@ -2,4 +2,5 @@ export type InputRadioGroupProps = {
   groupId: string;
   inline?: boolean;
   onChange?: (event?: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
 };

--- a/packages/react/ds/src/input-radio/input-radio.tsx
+++ b/packages/react/ds/src/input-radio/input-radio.tsx
@@ -35,16 +35,6 @@ export const getRadioWidth = (size?: InputRadioSizeType) => {
   return widthClass;
 };
 
-const addConditionalDivider = (
-  conditionalInput: InputTextProps | undefined,
-  checked?: boolean,
-) => {
-  if (conditionalInput && checked) {
-    return checked ? 'gi-block' : 'gi-invisible';
-  }
-  return 'gi-invisible';
-};
-
 export const InputRadio: React.FC<InputRadioProps> = ({
   label,
   hint,

--- a/packages/react/ds/src/select/select-next.stories.tsx
+++ b/packages/react/ds/src/select/select-next.stories.tsx
@@ -11,6 +11,7 @@ import {
   SelectItemNext,
   SelectNext,
 } from './select-next.js';
+import { useState } from 'react';
 
 const meta = {
   title: 'Form/Select/SelectNext',
@@ -310,5 +311,49 @@ export const WithGroups = {
     expect(canvas.getByText('Option 1')).toBeInTheDocument();
     expect(canvas.getByText('Option 8')).toBeInTheDocument();
     await userEvent.click(document.body);
+  },
+};
+
+export const Controlled: StoryObj = {
+  render: () => {
+    const [value, setValue] = useState('value-2');
+
+    return (
+      <FormField className="gi-w-56">
+        <FormFieldLabel>Controlled Select</FormFieldLabel>
+        <SelectNext
+          aria-label="Select"
+          id="select-controlled"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        >
+          <SelectItemNext value="select-option" hidden>
+            Select Option
+          </SelectItemNext>
+          <SelectItemNext value="value-1">Option 1</SelectItemNext>
+          <SelectItemNext value="value-2">Option 2</SelectItemNext>
+          <SelectItemNext value="value-3">Option 3</SelectItemNext>
+        </SelectNext>
+      </FormField>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Option 2');
+    });
+
+    await userEvent.click(input);
+
+    const list = await canvas.findByRole('list');
+    const options = within(list).getAllByRole('option');
+
+    await userEvent.click(options[2]); // "Option 3"
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Option 3');
+    });
   },
 };

--- a/packages/react/ds/src/select/select-next.tsx
+++ b/packages/react/ds/src/select/select-next.tsx
@@ -33,7 +33,7 @@ export const SelectNext = ({
   enableSearch,
   disabled,
   ...props
-}: SelectNextProps & { value?: string }) => {
+}: SelectNextProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [internalValue, setInternalValue] = useState(defaultValue);

--- a/packages/react/ds/src/select/select-next.tsx
+++ b/packages/react/ds/src/select/select-next.tsx
@@ -141,6 +141,7 @@ export const SelectNext = ({
       className={cn('gi-select-next', props.className)}
     >
       <InputText
+        id={props.id}
         aria-label="Select an option"
         aria-disabled={disabled}
         disabled={disabled}

--- a/packages/react/ds/src/select/select-next.tsx
+++ b/packages/react/ds/src/select/select-next.tsx
@@ -60,6 +60,7 @@ export const SelectNext = ({
 
   const handleOnOpenChange = (isOpen: boolean) => {
     setIsOpen(isOpen);
+
     if (onMenuClose && !isOpen) {
       onMenuClose();
     }
@@ -81,6 +82,7 @@ export const SelectNext = ({
         },
       } as unknown as React.ChangeEvent<HTMLSelectElement>;
 
+      // it dispatches a synthetic native event
       onSelectNextChange(event);
     }
   };
@@ -212,10 +214,7 @@ export const SelectNext = ({
                 });
 
               return (
-                <SelectMenuGroupItem
-                  key={`Group-${typedChild.props.label}`}
-                  label={typedChild.props.label}
-                >
+                <SelectMenuGroupItem label={typedChild.props.label}>
                   {groupOptions}
                 </SelectMenuGroupItem>
               );

--- a/packages/react/ds/src/select/types.ts
+++ b/packages/react/ds/src/select/types.ts
@@ -78,6 +78,7 @@ export type SelectNextProps = PropsWithChildren<
     onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
     onMenuClose?: () => void;
     defaultValue?: string;
+    value?: string;
     enableSearch?: boolean;
     disabled?: boolean;
   } & Omit<HTMLAttributes<HTMLDivElement>, `on${string}`>

--- a/packages/react/ds/src/textarea/textarea.stories.tsx
+++ b/packages/react/ds/src/textarea/textarea.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, within } from '@storybook/test';
+import { expect, userEvent, within } from '@storybook/test';
 import {
   FormField,
   FormFieldError,
@@ -7,6 +7,7 @@ import {
   FormFieldLabel,
 } from '../forms/form-field/form-field.js';
 import { TextArea } from './textarea.js';
+import React from 'react';
 
 const meta = {
   title: 'Form/TextArea',
@@ -256,4 +257,56 @@ export const CustomRowsAndColumns: Story = {
       <TextArea {...props} />
     </FormField>
   ),
+};
+
+export const Controlled: Story = {
+  args: {
+    id: 'textarea-controlled',
+    rows: 4,
+    cols: 50,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This example shows a controlled TextArea component where the value is managed by React state. The current value is displayed below the textarea and updates as the user types.',
+      },
+    },
+  },
+  render: (props) => {
+    const [value, setValue] = React.useState('Initial value');
+
+    return (
+      <FormField>
+        <FormFieldLabel htmlFor="textarea-controlled">
+          Controlled Label
+        </FormFieldLabel>
+        <TextArea
+          {...props}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          data-testid="textarea-controlled"
+        />
+        <FormFieldHint>Current: {value}</FormFieldHint>
+      </FormField>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const textarea = canvas.getByTestId(
+      'textarea-controlled',
+    ) as HTMLTextAreaElement;
+
+    expect(textarea.value).toBe('Initial value');
+
+    await textarea.focus();
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'New controlled text');
+
+    expect(textarea.value).toBe('New controlled text');
+
+    const hint = canvas.getByText(/Current:/);
+    expect(hint).toHaveTextContent('Current: New controlled text');
+  },
 };

--- a/packages/react/ds/src/textarea/textarea.tsx
+++ b/packages/react/ds/src/textarea/textarea.tsx
@@ -111,6 +111,7 @@ export const TextArea = forwardRef(
               data-icon-start={!!iconStart}
               data-clear-enabled={clearButtonEnabled}
               maxLength={maxChars}
+              value={currentValue}
               onChange={handleOnChange}
               {...props}
             />


### PR DESCRIPTION
## Description

- Update `InputCheckbox`, `InputRadio`, `TextArea`, `SelectNext`, and `ButtonGroup` with `value` props since our components offer controlled inputs.
- Update examples page with RHF (React Hook Form).

<img width="775" height="1010" alt="Screenshot 2025-07-17 at 12 23 52" src="https://github.com/user-attachments/assets/ea237673-8b2a-420d-bf23-14b4288f845d" />
<img width="1566" height="1012" alt="Screenshot 2025-07-17 at 12 24 03" src="https://github.com/user-attachments/assets/0dd64940-81fa-41cc-bdd0-48249bcd4850" />


## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [X] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [X] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.