### PR TITLE
fix: remove table styling from card image

### DIFF
--- a/packages/design/tailwind/css/components/card.css
+++ b/packages/design/tailwind/css/components/card.css
@@ -37,7 +37,7 @@
 }
 
 .gi-card-image {
-  @apply gi-table gi-items-start gi-self-stretch gi-w-full gi-h-auto;
+  @apply gi-items-start gi-self-stretch gi-w-full gi-h-auto;
 }
 
 .gi-card-image a {


### PR DESCRIPTION
## Description
Due to recent changes on tanstack grid, `gi-table` was updated and it caused the `gi-card-image` with unintentional changes. Removed `gi-table` in this PR.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
NA.

## Additional Notes
NA.