### PR TITLE
fix: toggle menu label visibility

### DIFF
--- a/apps/docs/content/3-components/2-library/header/react.mdx
+++ b/apps/docs/content/3-components/2-library/header/react.mdx
@@ -163,7 +163,8 @@ The Header component supports localisation through i18n keys in React, [find i18
   "header.mobileNavigationMenu": "Mobile Navigation Menu",
   "header.siteHeader": "Site Header",
   "header.goToHomePage": "Go to the home page",
-  "header.drawer.close": "Close"
+  "header.drawer.close": "Close",
+  "header.menu": "Menu"
 }
 ```
 

--- a/packages/html/ds/src/helpers/breadcrumbs.ts
+++ b/packages/html/ds/src/helpers/breadcrumbs.ts
@@ -1,5 +1,4 @@
 import { BreadcrumbsProps } from '../breadcrumbs/breadcrumbs.schema';
-import { beautifyHtmlNode } from '../storybook/storybook';
 import { createIcon } from './icons';
 import { createLink } from './links';
 

--- a/packages/html/ds/src/helpers/list.ts
+++ b/packages/html/ds/src/helpers/list.ts
@@ -1,5 +1,4 @@
 import { ListProps } from '../list/types';
-import { beautifyHtmlNode } from '../storybook/storybook';
 
 export const createList = (arguments_: ListProps) => {
   const container = document.createElement('div');

--- a/packages/react/ds/src/header/header.stories.tsx
+++ b/packages/react/ds/src/header/header.stories.tsx
@@ -150,7 +150,7 @@ export const Default: Story = {
     mobileMenuLabel: {
       control: 'text',
       description:
-        'Change the mobile menu label when "addDefaultMobileMenu" is set',
+        'Change the mobile menu label when "addDefaultMobileMenu" is set, if not provided it will default to "Menu"',
       table: {
         category: 'Header',
       },
@@ -163,6 +163,13 @@ export const Default: Story = {
         category: 'Header',
       },
     },
+    showMenuLabel: {
+      control: 'boolean',
+      description: 'If true, the menu label will be shown',
+      table: {
+        category: 'Header',
+      },
+    },
   },
   args: {
     logo: {
@@ -171,6 +178,7 @@ export const Default: Story = {
     items: headerProps.items,
     addDefaultMobileMenu: true,
     mobileMenuLabel: 'Menu',
+    showMenuLabel: true,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -852,5 +860,21 @@ export const TestWithSecondaryLinks: Story = {
     pseudo: {
       hover: '.gi-header-secondary-item',
     },
+  },
+};
+
+export const HideMenuLabel: Story = {
+  args: {
+    showMenuLabel: false,
+    fullWidth: true,
+    logo: {
+      href: '/link',
+    },
+    ...defaultHeaderProps(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const menuLabel = canvas.queryByText('Menu');
+    expect(menuLabel).not.toBeInTheDocument();
   },
 };

--- a/packages/react/ds/src/header/header.tsx
+++ b/packages/react/ds/src/header/header.tsx
@@ -157,7 +157,7 @@ export function Header({
   };
 
   const headerMenuLabel = showMenuLabel
-    ? mobileMenuLabel || t('header.menu', { defaultValue: 'Menu ' })
+    ? mobileMenuLabel || t('header.menu', { defaultValue: 'Menu' })
     : '';
 
   const finalItems = useMemo(() => {

--- a/packages/react/ds/src/header/header.tsx
+++ b/packages/react/ds/src/header/header.tsx
@@ -101,6 +101,7 @@ export function Header({
   fullWidth = false,
   addDefaultMobileMenu,
   mobileMenuLabel,
+  showMenuLabel = true,
   showTitleOnMobile,
   dataTestid,
 }: HeaderProps) {
@@ -155,14 +156,14 @@ export function Header({
     }
   };
 
+  const headerMenuLabel = showMenuLabel
+    ? mobileMenuLabel || t('header.menu', { defaultValue: 'Menu ' })
+    : '';
+
   const finalItems = useMemo(() => {
     const newItems = items || [];
     return addDefaultMobileMenu
-      ? buildDefaultMobileMenu(
-          mobileMenuLabel || 'Menu',
-          newItems,
-          secondaryLinks || [],
-        )
+      ? buildDefaultMobileMenu(headerMenuLabel, newItems, secondaryLinks || [])
       : newItems;
   }, [addDefaultMobileMenu]);
 

--- a/packages/react/ds/src/header/types.ts
+++ b/packages/react/ds/src/header/types.ts
@@ -78,6 +78,7 @@ export type HeaderProps = {
   logo?: LogoProps;
   addDefaultMobileMenu?: boolean;
   mobileMenuLabel?: string;
+  showMenuLabel?: boolean;
   items?: HeaderItem[];
   secondaryLinks?: SecondaryLink[];
   fullWidth?: boolean;

--- a/packages/react/ds/src/i18n/translations/en.json
+++ b/packages/react/ds/src/i18n/translations/en.json
@@ -28,6 +28,7 @@
       "header.siteHeader": "Site Header",
       "header.goToHomePage": "Go to the home page",
       "header.drawer.close": "Close",
+      "header.menu": "Menu",
       "input.search": "Search",
       "footer.goToHomePage": "Go to the home page",
       "footer.footer": "Footer",


### PR DESCRIPTION
## Description

- Add a boolean flag to hide/show menu label on header.

<img width="1000" height="860" alt="Screenshot 2025-08-13 at 16 12 51" src="https://github.com/user-attachments/assets/90986b4f-14cd-461d-bfbf-febf227f872e" />


## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [X] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.