### PR TITLE
fix: update input text component to accept react node for icon start/end

### DIFF
--- a/apps/docs/content/3-components/2-library/input-text/react.mdx
+++ b/apps/docs/content/3-components/2-library/input-text/react.mdx
@@ -22,12 +22,12 @@ component:
           description: 'Custom class name for styling the input element.'
           required: false
         - name: 'iconStart'
-          ofType: 'IconId'
-          description: 'ID of an icon to display at the start of the input.'
+          ofType: 'IconId | React.ReactNode'
+          description: 'ID of an icon to display at the start of the input. Can also be a React node.'
           required: false
         - name: 'iconEnd'
-          ofType: 'IconId'
-          description: 'ID of an icon to display at the end of the input.'
+          ofType: 'IconId | React.ReactNode'
+          description: 'ID of an icon to display at the end of the input. Can also be a React node.'
           required: false
         - name: 'inputActionButton'
           ofType: 'InputActionButtonProps'

--- a/apps/docs/dictionary.txt
+++ b/apps/docs/dictionary.txt
@@ -51,6 +51,7 @@ HeaderProps
 HeadingProps
 ICT
 IconButtonProps
+IconId
 IconProps
 Iframe
 InputCheckbox

--- a/packages/react/ds/src/input-text/input-text.stories.tsx
+++ b/packages/react/ds/src/input-text/input-text.stories.tsx
@@ -8,8 +8,8 @@ import {
 } from '../forms/form-field/form-field.js';
 import { Icon } from '../icon/icon.js';
 import { Link } from '../link/link.js';
-import { InputText } from './input-text.js';
 import { Spinner } from '../spinner/spinner.js';
+import { InputText } from './input-text.js';
 
 const meta = {
   title: 'Form/InputText',

--- a/packages/react/ds/src/input-text/input-text.stories.tsx
+++ b/packages/react/ds/src/input-text/input-text.stories.tsx
@@ -9,6 +9,7 @@ import {
 import { Icon } from '../icon/icon.js';
 import { Link } from '../link/link.js';
 import { InputText } from './input-text.js';
+import { Spinner } from '../spinner/spinner.js';
 
 const meta = {
   title: 'Form/InputText',
@@ -45,7 +46,7 @@ const meta = {
       control: 'text',
       table: {
         category: 'Visual',
-        type: { summary: 'IconId' },
+        type: { summary: 'IconId | React.ReactNode' },
       },
     },
     iconEnd: {
@@ -53,7 +54,7 @@ const meta = {
       control: 'text',
       table: {
         category: 'Visual',
-        type: { summary: 'IconId' },
+        type: { summary: 'IconId | React.ReactNode' },
       },
     },
     inputActionButton: {
@@ -302,6 +303,16 @@ export const InputWithIcons: Story = {
         iconEnd="placeholder"
         placeholder="Placeholder"
       />
+    </FormField>
+  ),
+};
+
+export const InputWithLoadingIcon: Story = {
+  render: () => (
+    <FormField>
+      <FormFieldLabel>Label</FormFieldLabel>
+      <FormFieldHint>Support text</FormFieldHint>
+      <InputText iconEnd={<Spinner size="md" />} placeholder="Placeholder" />
     </FormField>
   ),
 };

--- a/packages/react/ds/src/input-text/input-text.tsx
+++ b/packages/react/ds/src/input-text/input-text.tsx
@@ -141,7 +141,11 @@ const Input = forwardRef<HTMLInputElement, InputTextProps>(
               onClick={onIconEndClick}
               ref={iconEndRef}
             >
-              <Icon icon={iconEnd as IconId} size="md" disabled={disabled} />
+              {typeof iconEnd === 'string' ? (
+                <Icon icon={iconEnd as IconId} size="md" disabled={disabled} />
+              ) : (
+                iconEnd
+              )}
             </div>
           )}
           {renderActionButton}

--- a/packages/react/ds/src/input-text/input-text.tsx
+++ b/packages/react/ds/src/input-text/input-text.tsx
@@ -2,7 +2,7 @@
 
 import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import { cn } from '../cn.js';
-import { Icon } from '../icon/icon.js';
+import { Icon, IconId } from '../icon/icon.js';
 import { IconButton } from '../icon-button/icon-button.js';
 import { Input as PrimitiveInput } from '../primitives/input.js';
 import type {
@@ -108,7 +108,15 @@ const Input = forwardRef<HTMLInputElement, InputTextProps>(
               onClick={onIconStartClick}
               data-prefix={!!prefix}
             >
-              <Icon icon={iconStart} size="md" disabled={disabled} />
+              {typeof iconStart === 'string' ? (
+                <Icon
+                  icon={iconStart as IconId}
+                  size="md"
+                  disabled={disabled}
+                />
+              ) : (
+                iconStart
+              )}
             </div>
           )}
           <PrimitiveInput
@@ -133,7 +141,7 @@ const Input = forwardRef<HTMLInputElement, InputTextProps>(
               onClick={onIconEndClick}
               ref={iconEndRef}
             >
-              <Icon icon={iconEnd} size="md" disabled={disabled} />
+              <Icon icon={iconEnd as IconId} size="md" disabled={disabled} />
             </div>
           )}
           {renderActionButton}

--- a/packages/react/ds/src/input-text/type.ts
+++ b/packages/react/ds/src/input-text/type.ts
@@ -10,14 +10,16 @@ export type InputActionButtonProps = {
   ref?: React.Ref<HTMLButtonElement>;
 };
 
+type IconProp = IconId | React.ReactNode;
+
 export type InputTextProps = React.InputHTMLAttributes<HTMLInputElement> & {
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   inputClassName?: string;
-  iconStart?: IconId;
+  iconStart?: IconProp;
   onIconStartClick?: () => void;
   iconStartClassName?: string;
-  iconEnd?: IconId;
+  iconEnd?: IconId | React.ReactNode;
   iconEndClassName?: string;
   onIconEndClick?: () => void;
   inputActionButton?: InputActionButtonProps;

--- a/packages/react/ds/src/input-text/type.ts
+++ b/packages/react/ds/src/input-text/type.ts
@@ -19,7 +19,7 @@ export type InputTextProps = React.InputHTMLAttributes<HTMLInputElement> & {
   iconStart?: IconProp;
   onIconStartClick?: () => void;
   iconStartClassName?: string;
-  iconEnd?: IconId | React.ReactNode;
+  iconEnd?: IconProp;
   iconEndClassName?: string;
   onIconEndClick?: () => void;
   inputActionButton?: InputActionButtonProps;


### PR DESCRIPTION
## Description

- Add `ReactNode` type to `iconStart` and `iconEnd`.
- Example: Add spinner or other svg component.

<img width="694" height="247" alt="Screenshot 2025-08-13 at 20 37 54" src="https://github.com/user-attachments/assets/8f529441-d579-4c5e-b3e6-73780f831695" />



## Type of Issue

- [X] 🚀 Feature
- [ ] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [X] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.