### PR TITLE
fix: close modal on escape key AB#30184

### DIFF
--- a/packages/html/ds/src/modal/modal.ts
+++ b/packages/html/ds/src/modal/modal.ts
@@ -67,6 +67,7 @@ export class Modal extends BaseComponent<ModalOptions> {
   modalControl: Element | null;
   modalBody: any;
   ariaHiderCleanup: (() => void) | null = null;
+  handleEscapeKey: (event: KeyboardEvent) => void;
 
   constructor(options: ModalOptions) {
     super(options);
@@ -89,7 +90,7 @@ export class Modal extends BaseComponent<ModalOptions> {
     this.modalBody = this.query.getByElement({
       name: 'modal-body',
     });
-
+    this.handleEscapeKey = this.escapeKeyListener.bind(this);
     this.position = (this.modal as HTMLElement).dataset?.position || 'center';
     this.isOpen = (this.modal as HTMLElement).dataset?.open === 'true';
     this.closeOnClick =
@@ -132,7 +133,7 @@ export class Modal extends BaseComponent<ModalOptions> {
 
   toggleModalState(isOpen: boolean, props?: { forceClose?: boolean }) {
     const newDocument = (this.modal as HTMLElement).ownerDocument ?? document;
-
+    this.isOpen = isOpen;
     if (isOpen) {
       this.modal.classList.add('gi-modal-open');
       this.modal.classList.remove('gi-modal-close');
@@ -180,6 +181,13 @@ export class Modal extends BaseComponent<ModalOptions> {
     this.toggleModalState(false, { forceClose: true });
   }
 
+  escapeKeyListener(event: KeyboardEvent) {
+    if (event.key === 'Escape' && this.isOpen) {
+      event.stopPropagation();
+      this.toggleModalState(false, { forceClose: true });
+    }
+  }
+
   initComponent() {
     this.triggerButton?.addEventListener(
       'click',
@@ -187,6 +195,7 @@ export class Modal extends BaseComponent<ModalOptions> {
     );
     this.modal.addEventListener('click', this.modalEventListener);
     this.closeIcon?.addEventListener('click', this.closeButtonListener);
+    document.addEventListener('keydown', this.handleEscapeKey);
   }
 
   destroyComponent(): void {
@@ -197,6 +206,7 @@ export class Modal extends BaseComponent<ModalOptions> {
     this.modal.removeEventListener('click', this.modalEventListener);
     this.closeIcon?.removeEventListener('click', this.closeButtonListener);
     this.trap?.deactivate();
+    document.removeEventListener('keydown', this.handleEscapeKey);
   }
 }
 

--- a/packages/react/ds/src/modal/modal.tsx
+++ b/packages/react/ds/src/modal/modal.tsx
@@ -137,6 +137,24 @@ export const ModalWrapper = ({
       !isModalComponent(ModalFooter, 'ModalFooter', child),
   );
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   return (
     <ModalPortal modalRef={modalRef} isOpen={isOpen}>
       <div


### PR DESCRIPTION
## Description

Updated modal code to close on "Escape" key if it is open for React and HTML package.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.