### PR TITLE
fix: SelectNext placeholder and autocomplete="off" 

### DIFF
--- a/packages/react/ds/src/autocomplete/autocomplete.tsx
+++ b/packages/react/ds/src/autocomplete/autocomplete.tsx
@@ -268,6 +268,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
         className={cn('gi-autocomplete gi-not-prose', props.className)}
       >
         <InputText
+          autoComplete="off"
           id={id}
           name={name}
           onKeyDown={handleOnKeyDown}

--- a/packages/react/ds/src/select/select-next.tsx
+++ b/packages/react/ds/src/select/select-next.tsx
@@ -194,6 +194,7 @@ export const SelectNext = forwardRef<HTMLInputElement, SelectNextProps>(
           ref={inputRef}
           onBlur={onBlur}
           name={name}
+          placeholder={placeholder}
         >
           {children}
         </SelectSearch>
@@ -207,6 +208,7 @@ export const SelectNext = forwardRef<HTMLInputElement, SelectNextProps>(
       >
         <InputText
           {...props}
+          autoComplete="off"
           aria-label="Select an option"
           aria-disabled={disabled}
           disabled={disabled}


### PR DESCRIPTION
## Description

Adding placeholder when enableSearch and removing browser autocomplete.

## Type of Issue

- [ ] 🚀 Feature
- [x] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).
