### PR TITLE
fix: add data table column size for td and th

### DIFF
--- a/packages/design/tailwind/css/components/table.css
+++ b/packages/design/tailwind/css/components/table.css
@@ -25,6 +25,33 @@
   height: inherit;
 }
 
+.gi-table-th-xs-fixed,
+.gi-table-td-xs-fixed {
+  @apply gi-w-12 gi-max-w-12 gi-min-w-12;
+}
+
+.gi-table-th-sm-fixed,
+.gi-table-td-sm-fixed {
+  /* TODO Usage of token, create 30 as 120 */
+  @apply gi-w-[120px] gi-max-w-[120px] gi-min-w-[120px];
+}
+
+.gi-table-th-md-fixed,
+.gi-table-td-md-fixed {
+  @apply gi-w-48 gi-max-w-48 gi-min-w-48;
+}
+
+.gi-table-th-lg-flex,
+.gi-table-td-lg-flex {
+  @apply gi-w-60 gi-max-w-120 gi-min-w-60;
+}
+
+.gi-table-th-fluid,
+.gi-table-td-fluid {
+  /* TODO Usage of token, create 100 as 400px */
+  @apply gi-w-[400px] gi-min-w-[gi-px-3];
+}
+
 .gi-table-tr:last-child .gi-table-td {
   @apply gi-border-b-0;
 }

--- a/packages/design/tailwind/css/components/table.css
+++ b/packages/design/tailwind/css/components/table.css
@@ -49,7 +49,7 @@
 .gi-table-th-fluid,
 .gi-table-td-fluid {
   /* TODO Usage of token, create 100 as 400px */
-  @apply gi-w-[400px] gi-min-w-[gi-px-3];
+  @apply gi-w-[400px] gi-min-w-[400px];
 }
 
 .gi-table-tr:last-child .gi-table-td {

--- a/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
+++ b/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
@@ -251,6 +251,9 @@ export const WithReactHookForm: Story = {
           header: 'Full Name',
           cell: (info) => info.getValue(),
           filterFn: 'fuzzy',
+          meta: {
+            size: 'md-fixed',
+          },
         },
         {
           accessorKey: 'email',
@@ -650,7 +653,7 @@ export const WithReactHookForm: Story = {
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHeader
-                    size="fluid"
+                    size={(header.column.columnDef.meta as any)?.size}
                     id={header.id}
                     key={header.id}
                     sorted={header.column.getIsSorted()}

--- a/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
+++ b/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
@@ -645,7 +645,7 @@ export const WithReactHookForm: Story = {
           stripped
           className="gi-mt-4 gi-w-full"
         >
-          <TableHead>
+          <TableHead size="fluid">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (

--- a/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
+++ b/packages/react/ds/src/data-table/tanstack/tanstack.stories.tsx
@@ -645,11 +645,12 @@ export const WithReactHookForm: Story = {
           stripped
           className="gi-mt-4 gi-w-full"
         >
-          <TableHead size="fluid">
+          <TableHead>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHeader
+                    size="fluid"
                     id={header.id}
                     key={header.id}
                     sorted={header.column.getIsSorted()}

--- a/packages/react/ds/src/table/table-data.tsx
+++ b/packages/react/ds/src/table/table-data.tsx
@@ -11,10 +11,13 @@ import { cn } from '../cn.js';
 import { IconButton } from '../icon-button/icon-button.js';
 import { TableAlign, VerticalAlign } from './table.js';
 
+type TableDataSize = 'xs-fixed' | 'sm-fixed' | 'md-fixed' | 'lg-flex' | 'fluid';
+
 interface TableDataProps extends TdHTMLAttributes<HTMLTableCellElement> {
   align?: TableAlign;
   valign?: VerticalAlign;
   tableCellClassName?: string;
+  size?: TableDataSize;
   children: any;
 }
 
@@ -33,6 +36,7 @@ type TableDataSlotProps = Omit<TableDataProps, 'align' | 'valign'>;
 export function TableData({
   align = 'left',
   valign = 'middle',
+  size,
   className,
   children,
   tableCellClassName,
@@ -49,6 +53,8 @@ export function TableData({
     middle: 'gi-align-middle',
     bottom: 'gi-align-bottom',
   }[valign];
+
+  const sizeClass = size ? `gi-table-td-${size}` : undefined;
 
   const ref = useRef<HTMLTableCellElement>(null);
   const [hasFormElement, setHasFormElement] = useState(false);
@@ -67,6 +73,7 @@ export function TableData({
       ref={ref}
       className={cn(
         'gi-table-td',
+        sizeClass,
         alignmentClass,
         verticalAlignmentClass,
         className,

--- a/packages/react/ds/src/table/table-head.tsx
+++ b/packages/react/ds/src/table/table-head.tsx
@@ -1,8 +1,29 @@
+import clsx from 'clsx';
 import React from 'react';
+
+export type TableHeadSize =
+  | 'xs-fixed'
+  | 'sm-fixed'
+  | 'md-fixed'
+  | 'lg-flex'
+  | 'fluid';
+
+export interface TableHeadProps
+  extends React.TableHTMLAttributes<HTMLTableSectionElement> {
+  size?: TableHeadSize;
+}
 
 export function TableHead({
   children,
+  size,
+  className,
   ...props
-}: React.TableHTMLAttributes<HTMLTableSectionElement>) {
-  return <thead {...props}>{children}</thead>;
+}: TableHeadProps) {
+  const sizeClass = size ? `gi-table-th-${size}` : undefined;
+
+  return (
+    <thead {...props} className={clsx(sizeClass, className)}>
+      {children}
+    </thead>
+  );
 }

--- a/packages/react/ds/src/table/table-head.tsx
+++ b/packages/react/ds/src/table/table-head.tsx
@@ -1,29 +1,8 @@
-import clsx from 'clsx';
 import React from 'react';
-
-export type TableHeadSize =
-  | 'xs-fixed'
-  | 'sm-fixed'
-  | 'md-fixed'
-  | 'lg-flex'
-  | 'fluid';
-
-export interface TableHeadProps
-  extends React.TableHTMLAttributes<HTMLTableSectionElement> {
-  size?: TableHeadSize;
-}
 
 export function TableHead({
   children,
-  size,
-  className,
   ...props
-}: TableHeadProps) {
-  const sizeClass = size ? `gi-table-th-${size}` : undefined;
-
-  return (
-    <thead {...props} className={clsx(sizeClass, className)}>
-      {children}
-    </thead>
-  );
+}: React.TableHTMLAttributes<HTMLTableSectionElement>) {
+  return <thead {...props}>{children}</thead>;
 }

--- a/packages/react/ds/src/table/table-header.tsx
+++ b/packages/react/ds/src/table/table-header.tsx
@@ -6,11 +6,19 @@ import { TableAlign, VerticalAlign } from './table.js';
 
 type SortedType = 'asc' | 'desc' | false;
 
+export type TableHeaderSize =
+  | 'xs-fixed'
+  | 'sm-fixed'
+  | 'md-fixed'
+  | 'lg-flex'
+  | 'fluid';
+
 interface TableHeaderProps extends ThHTMLAttributes<HTMLTableCellElement> {
   align?: TableAlign;
   valign?: VerticalAlign;
   sorted?: SortedType;
   onSort?: (event: React.MouseEvent) => void;
+  size?: TableHeaderSize;
 }
 
 const getSortedIcon = (isChildrenString: boolean, sorted: SortedType) => {
@@ -37,6 +45,7 @@ export function TableHeader({
   sorted = false,
   onSort,
   children,
+  size,
   ...props
 }: TableHeaderProps) {
   const isChildrenString = typeof children === 'string';
@@ -51,6 +60,8 @@ export function TableHeader({
     middle: 'gi-align-middle',
     bottom: 'gi-align-bottom',
   }[valign];
+
+  const sizeClass = size ? `gi-table-th-${size}` : undefined;
 
   const handleSort = (event: any) => {
     if (onSort && isChildrenString) {
@@ -79,6 +90,7 @@ export function TableHeader({
         alignmentClass,
         verticalAlignmentClass,
         'gi-table-th',
+        sizeClass,
         className,
         { 'gi-w-12': !isChildrenString },
       )}


### PR DESCRIPTION
## Description
Add data table column size classes.

## Type of Issue

- [ ] 🚀 Feature
- [X] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.