### PR TITLE
docs: add storybook for FormField storybook instance

### DIFF
--- a/packages/react/ds/src/forms/form-field.stories.tsx
+++ b/packages/react/ds/src/forms/form-field.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { InputText } from '../input-text/input-text.js';
+import { TextArea } from '../textarea/textarea.js';
+import {
+  FormField,
+  FormFieldLabel,
+  FormFieldHint,
+  FormFieldError,
+} from './form-field/form-field.js';
+
+const meta = {
+  title: 'Form/FormField',
+  component: FormField,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `FormField` component provides a flexible wrapper for form inputs. ' +
+          'It is designed to work with associated subcomponents like `FormFieldLabel`, ' +
+          '`FormFieldHint`, and `FormFieldError` for building accessible and consistent form fields.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      description: 'Default label text',
+      control: { type: 'object' },
+    },
+    hint: {
+      description: 'Default hint text',
+      control: { type: 'object' },
+    },
+    error: {
+      description: 'Default error message',
+      control: { type: 'object' },
+    },
+    className: {
+      description: 'Custom class name for the FormField container',
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    label: {
+      text: 'Label text goes here.',
+      size: 'md',
+    },
+    hint: {
+      text: 'Hint text goes here.',
+      size: 'md',
+    },
+    error: { text: 'Error text goes here.', size: 'md' },
+    className: '',
+  },
+} satisfies Meta<typeof FormField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <FormField data-testid="form-field-default">
+      <FormFieldLabel htmlFor="input-text-id">Label</FormFieldLabel>
+      <InputText data-testid="input-text-id" id="input-text-id" />
+    </FormField>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A basic `FormField` with a label and an input. This demonstrates the simplest usage.',
+      },
+    },
+  },
+};
+
+export const WithHint: Story = {
+  render: () => (
+    <FormField>
+      <FormFieldLabel htmlFor="input-with-hint">Username</FormFieldLabel>
+      <FormFieldHint>Choose a unique username for your account.</FormFieldHint>
+      <InputText id="input-with-hint" />
+    </FormField>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Adds a `FormFieldHint` below the label to provide guidance or instructions to the user.',
+      },
+    },
+  },
+};
+
+export const WithError: Story = {
+  render: () => (
+    <FormField>
+      <FormFieldLabel htmlFor="input-with-error">Email</FormFieldLabel>
+      <FormFieldError>Please enter a valid email address.</FormFieldError>
+      <InputText id="input-with-error" />
+    </FormField>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Includes a `FormFieldError` message to indicate a validation error. ' +
+          'When an error is present, the fieldset applies an error state style.',
+      },
+    },
+  },
+};
+
+export const WithHintAndError: Story = {
+  render: () => (
+    <FormField>
+      <FormFieldLabel htmlFor="textarea-id">Description</FormFieldLabel>
+      <FormFieldHint>
+        Provide a short description (max 200 characters).
+      </FormFieldHint>
+      <FormFieldError>Description is required.</FormFieldError>
+      <TextArea id="textarea-id" />
+    </FormField>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows how you can combine both `FormFieldHint` and `FormFieldError` within the same field.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Description

Add `FormField` storybook documentation.

<img width="1140" height="548" alt="Screenshot 2025-09-25 at 14 03 32" src="https://github.com/user-attachments/assets/4a0c84f9-a0e0-4b3c-8c90-bd467d55d919" />


## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [ ] 🔧 Chore
- [X] 🌐 Docs

## Checklist

- [X] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
N/A.

## Additional Notes
N/A.