### PR TITLE
ci(AB#37146): update `.trivyignore` with non-exploitable CVE-2026-28390 details

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,5 @@
-# CVE-2026-22184: zlib contrib/untgz demo utility buffer overflow
-# Not exploitable - untgz is not installed or used in the container
-CVE-2026-22184
+# CVE-2026-28390: OpenSSL NULL dereference in CMS KeyTransportRecipientInfo processing
+# Not exploitable - nginx does not use OpenSSL CMS (S/MIME/PKCS#7) functions.
+# DHI marks it as not-affected via VEX, but Trivy does not consume the VEX feed.
+# Upstream fix: OpenSSL 3.0.13 / 3.1.5 / 3.4.5 (Alpine 3.23.3+).
+CVE-2026-28390


### PR DESCRIPTION
## Description

Remove `CVE-2026-22184` as resolved.

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [x] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

[AB#37146](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/37146)
