### PR TITLE
ci: fully qualified image name used in gitops AB#36947

### DIFF
--- a/.azure/pipeline.yaml
+++ b/.azure/pipeline.yaml
@@ -123,7 +123,7 @@ stages:
         environment:
           applications:
             - name: ${{ parameters.application.name }}
-              image: ${{ parameters.application.imageName }}
+              image: $(awsEcrRepository)/${{ parameters.application.imageName }}
         variables:
           overlaysPath: $[ stageDependencies.configureDeployment.configureDeployment.outputs['configureVariables.OVERLAYS_PATH'] ]
         dependsOnStages:


### PR DESCRIPTION
## Description

<!-- A brief description of the feature made. -->

Use fully qualified image name in deployment stage.

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [x] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

<!-- List any related issues or pull requests (e.g., "Fixes #123"). -->

[AB#36947](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/36947)

