### PR TITLE
feat(AB#38216): prioritise key libraries on the Releases page

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,12 +1,12 @@
 {
-  "apps/docs": "1.35.0",
   "packages/build/eslint-config": "1.4.1",
   "packages/build/prettier-config": "1.1.1",
-  "packages/design/tailwind": "1.25.0",
+  "packages/design/figma": "1.0.5",
   "packages/design/theme-builder": "1.24.0",
-  "packages/html/ds": "1.21.1",
-  "packages/react": "1.36.0",
-  "packages/themes/govie": "1.21.5",
   "packages/design/tokens": "1.22.1",
-  "packages/design/figma": "1.0.5"
+  "apps/docs": "1.35.0",
+  "packages/themes/govie": "1.21.5",
+  "packages/design/tailwind": "1.25.0",
+  "packages/html/ds": "1.21.1",
+  "packages/react": "1.36.0"
 }

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -39,7 +39,7 @@ description:
     features:
       - React component library
       - HTML component library
-      - Angular component library (alpha)1
+      - Angular component library (alpha)
       - Tailwind CSS styling and theming
       - Design tokens for consistent styling
       - Theme packages

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,10 +46,6 @@
     }
   ],
   "packages": {
-    "apps/docs": {
-      "component": "docs",
-      "release-type": "node"
-    },
     "packages/build/eslint-config": {
       "component": "eslint-config",
       "release-type": "node"
@@ -58,12 +54,28 @@
       "component": "prettier-config",
       "release-type": "node"
     },
-    "packages/design/tailwind": {
-      "component": "design-tailwind",
+    "packages/design/figma": {
+      "component": "figma",
       "release-type": "node"
     },
     "packages/design/theme-builder": {
       "component": "design-theme-builder",
+      "release-type": "node"
+    },
+    "packages/design/tokens": {
+      "component": "tokens",
+      "release-type": "node"
+    },
+    "apps/docs": {
+      "component": "docs",
+      "release-type": "node"
+    },
+    "packages/themes/govie": {
+      "component": "themes-govie",
+      "release-type": "node"
+    },
+    "packages/design/tailwind": {
+      "component": "design-tailwind",
       "release-type": "node"
     },
     "packages/html/ds": {
@@ -72,18 +84,6 @@
     },
     "packages/react": {
       "component": "react-lib",
-      "release-type": "node"
-    },
-    "packages/themes/govie": {
-      "component": "themes-govie",
-      "release-type": "node"
-    },
-    "packages/design/tokens": {
-      "component": "tokens",
-      "release-type": "node"
-    },
-    "packages/design/figma": {
-      "component": "figma",
       "release-type": "node"
     }
   },


### PR DESCRIPTION
## Description

GitHub's Releases page sorts entries by `published_at`, and release-please creates them in the same order as `packages` keys in `release-please-config.json` — reordering the keys reorders the page. Consumer-facing libraries now publish last and land on top, motivated by the upcoming listing in the EU OSS Catalogue.

## Type of Issue

- [x] 🚀 Feature
- [ ] 🐛 Bug
- [ ] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

[AB#38216](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/38216)