### PR TITLE
ci(AB#39096): skip gh asset upload when library not in current release

### DIFF
--- a/.azure/templates/publish-gh-assets.yml
+++ b/.azure/templates/publish-gh-assets.yml
@@ -5,15 +5,34 @@ steps:
     inputs:
       targetType: inline
       script: |
+        set -euo pipefail
+
+        TODAY=$(date -u +%F)
+
+        released_today() {
+          gh release list --limit 15 --json tagName,createdAt \
+            --jq "first(.[] | select(.tagName | contains(\"$1\")) | select(.createdAt | startswith(\"$TODAY\")) | .tagName)"
+        }
+
+        HTML_TAG=$(released_today "html-lib")
+        THEME_TAG=$(released_today "themes-govie")
+
+        if [ -z "$HTML_TAG" ] && [ -z "$THEME_TAG" ]; then
+          echo "Nothing to publish."
+          exit 0
+        fi
+
         echo "Creating dist"
         pnpm run dist
 
-        echo "Uploading html artifacts to GitHub release"
-        HTML_TAG=$(gh release list --json tagName --jq 'first(.[].tagName | select(contains("html-lib")))')
-        gh release upload --clobber $HTML_TAG ./packages/html/ds/govie-frontend.zip
+        if [ -n "$HTML_TAG" ]; then
+          echo "Uploading html artifacts to GitHub release $HTML_TAG"
+          gh release upload --clobber "$HTML_TAG" ./packages/html/ds/govie-frontend.zip
+        fi
 
-        echo "Uploading theme artifacts to GitHub release"
-        THEME_TAG=$(gh release list --limit 200 --json tagName --jq 'first(.[].tagName | select(contains("themes-govie")))')
-        gh release upload --clobber $THEME_TAG ./packages/themes/govie/theme.zip
+        if [ -n "$THEME_TAG" ]; then
+          echo "Uploading theme artifacts to GitHub release $THEME_TAG"
+          gh release upload --clobber "$THEME_TAG" ./packages/themes/govie/theme.zip
+        fi
     env:
       GITHUB_TOKEN: $(githubTokenADO)


### PR DESCRIPTION
## Description

Only publish the html and themes zips when those libraries are actually part of the current release, instead of re-uploading them onto the previous release every cycle.

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [x] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

[AB#39096](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/39096)