### PR TITLE
ci(AB#39462): ignore non-exploitable OpenSSL CVE batch in image scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,1 +1,16 @@
-ignore: []
+# OpenSSL June 2026 advisory batch (libssl3/libcrypto3 3.5.6-r1, fixed in 3.5.7-r0).
+# Not exploitable - the affected code paths are PKCS#7/S/MIME verification,
+# CMS decryption, ASN.1 message parsing and the QUIC server: nginx in this image
+# serves static files only and does not terminate TLS (the OpenShift router does),
+# so none of these paths are reachable with attacker-controlled input.
+# Remove this block once the base image ships OpenSSL >= 3.5.7-r0.
+ignore:
+  - vulnerability: CVE-2026-45447
+  - vulnerability: CVE-2026-9076
+  - vulnerability: CVE-2026-7383
+  - vulnerability: CVE-2026-34180
+  - vulnerability: CVE-2026-42764
+  - vulnerability: CVE-2026-45445
+  - vulnerability: CVE-2026-34183
+  - vulnerability: CVE-2026-34182
+  - vulnerability: CVE-2026-34181

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,15 @@
-# CVE-2026-28390: OpenSSL NULL dereference in CMS KeyTransportRecipientInfo processing
-# Not exploitable - nginx does not use OpenSSL CMS (S/MIME/PKCS#7) functions.
-# DHI marks it as not-affected via VEX, but Trivy does not consume the VEX feed.
-# Upstream fix: OpenSSL 3.0.13 / 3.1.5 / 3.4.5 (Alpine 3.23.3+).
-CVE-2026-28390
+# OpenSSL June 2026 advisory batch (libssl3/libcrypto3 3.5.6-r1, fixed in 3.5.7-r0).
+# Not exploitable - the affected code paths are PKCS#7/S/MIME verification,
+# CMS decryption, ASN.1 message parsing and the QUIC server: nginx in this image
+# serves static files only and does not terminate TLS (the OpenShift router does),
+# so none of these paths are reachable with attacker-controlled input.
+# Remove this block once the base image ships OpenSSL >= 3.5.7-r0.
+CVE-2026-45447
+CVE-2026-9076
+CVE-2026-7383
+CVE-2026-34180
+CVE-2026-42764
+CVE-2026-45445
+CVE-2026-34183
+CVE-2026-34182
+CVE-2026-34181


### PR DESCRIPTION
## Description

Unblock image scans until a base-image rebuild ships OpenSSL 3.5.7-r0: the June 2026 advisory batch is fixed upstream but not yet in any published DHI nginx, and none of the affected code paths (PKCS#7/S-MIME, CMS, ASN.1 parsing, QUIC) are reachable in a static-serving nginx that does not terminate TLS.

The CVE-2026-28390 entry is dropped: fixed since openssl 3.5.6-r0, no longer reported.

## Type of Issue

- [ ] 🚀 Feature
- [ ] 🐛 Bug
- [x] 🔧 Chore
- [ ] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues

[AB#39462](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/39462)