### PR TITLE
fix(AB#39664): Prevent MDX wrapping LinkButton text in paragraph

### DIFF
--- a/apps/docs/content/3-components/2-library/link-button/design.mdx
+++ b/apps/docs/content/3-components/2-library/link-button/design.mdx
@@ -16,7 +16,7 @@ It keeps the implicit `link` role so browser link behaviours (right-click "Open 
 
 <ComponentPreview>
   <LinkButton href="https://ds.services.gov.ie/">
-    This is a link button
+    {`This is a link button`}
   </LinkButton>
 </ComponentPreview>
 

--- a/apps/docs/content/3-components/2-library/link-button/react.mdx
+++ b/apps/docs/content/3-components/2-library/link-button/react.mdx
@@ -127,7 +127,7 @@ It keeps the implicit `link` role so browser link behaviours (right-click "Open 
 
 <ComponentPreview>
   <LinkButton href="https://ds.services.gov.ie/">
-    This is a link button
+    {`This is a link button`}
   </LinkButton>
 </ComponentPreview>
 


### PR DESCRIPTION
## Description

Prevent MDX wrapping LinkButton text in paragraph

## Type of Issue

- [ ] 🚀 Feature
- [x] 🐛 Bug
- [ ] 🔧 Chore
- [x] 🌐 Docs

## Checklist

- [ ] I have included relevant attachments for user testing (e.g., screenshots of Storybook showcasing the changes).
- [ ] I have added/updated tests to cover the changes made (if applicable).
- [ ] I have updated the documentation site content (if applicable).
- [ ] I have added or updated the example folder to reflect any component changes (if applicable).

## Related Issues
[AB#39664](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/39664)
